### PR TITLE
Use fns instead of relying on named! macro

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,12 +18,22 @@ fn main() {
         /* Read user input line */
         io::stdin().read_line(&mut x).expect("Failed to read line");
 
-        x = parser::parse(&x.to_owned());
-
         /* Record input */
         input_history.push(x.clone());
 
-        /* Print user input line */
-        println!("{}", x);
+        /*  TOUNDERSTAND: Why does "let parsed_input_expression = parser::parse(&x.to_owned());" not work?
+            Parse input into expression tree */
+        let to_parse = x.to_owned();
+        let parsed_input_expression = parser::parse(&to_parse);
+
+        /* Print user input line (just the parsed tree for now) */
+        match parsed_input_expression {
+            Ok((_, expr)) => {
+                println!("{}", parser::eval(expr));
+            }
+            Err(_) => {
+                println!("Fuck you, boah")
+            }
+        }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
 use nom::{
     branch::alt,
     bytes::complete::{take_while, take_while1},
+    sequence::delimited,
     character::{is_space, is_digit},
     character::complete::{char, one_of},
     combinator::{cut, map, opt, value},
@@ -8,9 +9,9 @@ use nom::{
 };
 
 #[derive(Debug)]
-enum Expression2 {
+pub enum Expression2 {
     Num(i32),
-    Expr(char, Box<Expression2>, Box<Expression2>)
+    Expr(char, Box<Expression2>, Box<Expression2>),
 }
 
 /* WIP: Structure of recursive parser seems correct, we're fighting the nom DSL syntax now.
@@ -24,102 +25,41 @@ enum Expression2 {
    But we'll pretend the first element has to be an operator for now, and that the operands can be recursive. */
 
 fn parse_num2(i: &[u8]) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
-    let first_spaces: IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while(is_space)(i);
-    match first_spaces {
-        Ok((rest, _)) => {
-            let digits: IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while1(is_digit)(rest);
-            match digits {
-                Ok((rest, num)) => {
-                    let end_spaces:  IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while(is_space)(rest);
-                    match end_spaces {
-                        Ok((rest, _)) => {
-                            Ok((rest, Expression2::Num(from_u8_array_to_i32(num))))
-                        }
-                        Err(_) => {
-                            panic!("Impossivel kk")
-                        }
-                    }
-                }
-                Err(_) =>
-                    panic!("Preguiça de fazer essa porra desse pattern matching funcionar")
-            }
-        }
-        Err(_) => panic!("Impossivel he!")
-    }
+    let (rest, _first_spaces) = take_while(is_space)(i)?;
+    let (rest, digit) = take_while1(is_digit)(rest)?;
+    let (rest, _end_spaces) = take_while(is_space)(rest)?;
+
+    Ok((rest, Expression2::Num(from_u8_array_to_i32(digit))))
 }
 
 fn parse_expression2(i: &[u8]) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
-    let first_spaces: IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while(is_space)(i);
-    // ai aqui falta a porra do operador kk mas porra da pra ver que ta indo bem a porra
-    match first_spaces {
-        Ok((rest, _)) => {
-            let operand1: IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> = parse_expression_top_level(rest);
-            match operand1 {
-                Ok((rest, exprOp1)) => {
-                    let operand2: IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> = parse_expression_top_level(rest);
-                    match operand2 {
-                        Ok((rest, _)) => {
-                            Ok((rest, Expression2::Num(from_u8_array_to_i32(num))))
-                        }
-                        Err(_) => {
-                            panic!("Impossivel kk")
-                        }
-                    }
-                }
-                Err(_) =>
-                    panic!("Preguiça de fazer essa porra desse pattern matching funcionar")
-            }
-        }
-        Err(_) => panic!("Impossivel he!")
-    }
+    let (rest, _paren1) = char('(')(i)?;
+    let (rest, _first_spaces) = take_while(is_space)(rest)?;
+    let (rest, op) = one_of("+-/*")(rest)?;
+    let (rest, _spaces_between_operator_and_first_operand) = take_while1(is_space)(rest)?;
+    let (rest, expr_op1) = parse_expression_top_level(rest)?;
+    let (rest, expr_op2) = parse_expression_top_level(rest)?;
+    let (rest, _paren2) = char(')')(rest)?;
+
+    Ok((rest, Expression2::Expr(op, Box::new(expr_op1), Box::new(expr_op2))))
 }
 
 fn parse_expression_top_level(i: &[u8]) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
-    alt ((parse_expression, parse_num2))(i)
+    alt((parse_num2, parse_expression2))(i)
 }
 
-named!(
-    parse_num<Expression2>,
-    do_parse!(
-        take_while!(is_space) >>
-        num: take_while1!(is_digit) >>
-        take_while!(is_space) >>
-        (Expression2::Num(
-            from_u8_array_to_i32(num)
-        ))
-    )
-);
-
-named!(
-    parse_expression<Expression2>,
-    delimited!(
-        char!('('),
-        do_parse!(
-            operator: one_of!("+-/*") >>
-            take_while1!(is_space) >>
-            operand1: parse_expression_top_level() >>
-            take_while1!(is_space) >>
-            operand2: parse_expression_top_level() >>
-            take_while1!(is_space) >>
-            (Expr(
-                operator,
-                operand1,
-                operand2
-             ))),
-        char!(')'))
-
-);
-
-fn from_u8_array_to_i32(input: &[u8]) -> i32{
+fn from_u8_array_to_i32(input: &[u8]) -> i32 {
     std::str::from_utf8(input)
-            . expect("Error byte array -> string")
-            . parse()
-            . expect("Error string -> i32")
+        .expect("Error byte array -> string")
+        .parse()
+        .expect("Error string -> i32")
 }
 
-pub fn parse(input : &str) -> String {
+pub fn parse(input: &str) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
     let expression = parse_expression_top_level(input.as_bytes());
-    println!("{:?}", expression);
-    // FIXME: no explaination needed here unless you have Deco's IQ
-    String::from("aaa")
+    expression
+}
+
+pub fn eval (expr: Expression2) -> String {
+     format!("{:?}", expr)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,36 +1,18 @@
-use nom::character::{is_space, is_digit};
+use nom::{
+    branch::alt,
+    bytes::complete::{take_while, take_while1},
+    character::{is_space, is_digit},
+    character::complete::{char, one_of},
+    combinator::{cut, map, opt, value},
+    Err, IResult,
+};
 
 #[derive(Debug)]
-struct Expression {
-    operator: char,
-    operand1: i32,
-    operand2: i32
-}
-
 enum Expression2 {
     Num(i32),
     Expr(char, Box<Expression2>, Box<Expression2>)
 }
 
-/* Defining the polish notation parser
- * Eg:
- *      + 1 2 = 1 + 2
- */
-named!(
-    operators<Expression>,
-    do_parse!(
-        operator: one_of!("+-/*") >>
-        take_while1!(is_space) >>
-        operand1: take_while1!(is_digit) >>
-        take_while1!(is_space) >>
-        operand2: take_while1!(is_digit) >>
-        (Expression{
-            operator: operator,
-            operand1: from_u8_array_to_i32(operand1),
-            operand2: from_u8_array_to_i32(operand2)
-        })
-    )
-);
 /* WIP: Structure of recursive parser seems correct, we're fighting the nom DSL syntax now.
    An expression is either a simple literal (first branch of the alt! below) , or an open-parentheses
    expression with an operator in front. It actually doesn't have to be an operator, could be yet another
@@ -40,13 +22,61 @@ named!(
       (((((function-that-returns-another-function arg1 arg2) arg3) arg4) arg5) arg6)
 
    But we'll pretend the first element has to be an operator for now, and that the operands can be recursive. */
-named!(
-    parse_expression_top_level<Expression2>,
-    alt! (
-        parse_num |
-        parse_expression
-    )
-);
+
+fn parse_num2(i: &[u8]) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
+    let first_spaces: IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while(is_space)(i);
+    match first_spaces {
+        Ok((rest, _)) => {
+            let digits: IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while1(is_digit)(rest);
+            match digits {
+                Ok((rest, num)) => {
+                    let end_spaces:  IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while(is_space)(rest);
+                    match end_spaces {
+                        Ok((rest, _)) => {
+                            Ok((rest, Expression2::Num(from_u8_array_to_i32(num))))
+                        }
+                        Err(_) => {
+                            panic!("Impossivel kk")
+                        }
+                    }
+                }
+                Err(_) =>
+                    panic!("Preguiça de fazer essa porra desse pattern matching funcionar")
+            }
+        }
+        Err(_) => panic!("Impossivel he!")
+    }
+}
+
+fn parse_expression2(i: &[u8]) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
+    let first_spaces: IResult<&[u8], &[u8], (&[u8], nom::error::ErrorKind)> = take_while(is_space)(i);
+    // ai aqui falta a porra do operador kk mas porra da pra ver que ta indo bem a porra
+    match first_spaces {
+        Ok((rest, _)) => {
+            let operand1: IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> = parse_expression_top_level(rest);
+            match operand1 {
+                Ok((rest, exprOp1)) => {
+                    let operand2: IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> = parse_expression_top_level(rest);
+                    match operand2 {
+                        Ok((rest, _)) => {
+                            Ok((rest, Expression2::Num(from_u8_array_to_i32(num))))
+                        }
+                        Err(_) => {
+                            panic!("Impossivel kk")
+                        }
+                    }
+                }
+                Err(_) =>
+                    panic!("Preguiça de fazer essa porra desse pattern matching funcionar")
+            }
+        }
+        Err(_) => panic!("Impossivel he!")
+    }
+}
+
+fn parse_expression_top_level(i: &[u8]) -> IResult<&[u8], Expression2, (&[u8], nom::error::ErrorKind)> {
+    alt ((parse_expression, parse_num2))(i)
+}
 
 named!(
     parse_num<Expression2>,
@@ -54,7 +84,7 @@ named!(
         take_while!(is_space) >>
         num: take_while1!(is_digit) >>
         take_while!(is_space) >>
-        (Num(
+        (Expression2::Num(
             from_u8_array_to_i32(num)
         ))
     )
@@ -88,7 +118,7 @@ fn from_u8_array_to_i32(input: &[u8]) -> i32{
 }
 
 pub fn parse(input : &str) -> String {
-    let expression = operators(input.as_bytes());
+    let expression = parse_expression_top_level(input.as_bytes());
     println!("{:?}", expression);
     // FIXME: no explaination needed here unless you have Deco's IQ
     String::from("aaa")


### PR DESCRIPTION
This will help make our life easier with recursion and such. Most of the struggle is figuring out the return types of the different constructs `nom` gives us. My understanding is that, when you have a macro named `my_macro`, say, and it takes a single argument and returns a function, doing `my_macro!(some_arg)` both _expands_ the macro _and_ calls the resulting function it produces. However, doing `my_macro(some_arg)` (without the `bang!`) simply returns the function it produces, meaning something like this `my_macro(some_arg)(some_other_arg)` could make sense (and that's how this PR is using `take_while` among others).

EDIT: This style is very reminiscent of `do` notation in Haskell. The `?` operator suggested by the God @gabaconrado gives us a short circuiting way of piping the the result of parsers to the next ones.

The next step is to implement variadic arguments and expressions as operators (the first argument to a list doesn't have to be a `char`, it can be an entire expression). Also, not every atom is a Num, so we'll make that into a rich enum as well.