### PR TITLE
Built-in arithmetic functions and evaluation errors

### DIFF
--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,0 +1,15 @@
+pub fn sum(x: i64, y: i64) -> i64 {
+    x + y
+}
+
+pub fn sub(x: i64, y: i64) -> i64 {
+    x - y
+}
+
+pub fn mul(x: i64, y: i64) -> i64 {
+    x * y
+}
+
+pub fn div(x: i64, y: i64) -> i64 {
+    x / y
+}

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,5 +1,5 @@
-use parser::{Expression, Atom, EvaluationError};
 use parser::EvalResult;
+use parser::{Atom, EvaluationError, Expression};
 
 pub fn neg(args: Vec<Expression>) -> EvalResult {
     let args_amount = args.len();
@@ -7,61 +7,148 @@ pub fn neg(args: Vec<Expression>) -> EvalResult {
         Err(EvaluationError::WrongArity(1, args_amount as i64))
     } else {
         match &args[0] {
-            Expression::At(atom) => {
-                match atom {
-                    Atom::Int(i) =>{ Ok(Expression::At(Atom::Int(i * (-1)))) }
-                    _ => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
-                }
-            }
-            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+            Expression::At(atom) => match atom {
+                Atom::Int(i) => Ok(Expression::At(Atom::Int(i * (-1)))),
+                _ => Err(EvaluationError::WrongType(
+                    "atom but not integer".parse().unwrap(),
+                )),
+            },
+            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
         }
     }
 }
 
-pub fn sum(args: Vec<Expression>) -> EvalResult {
-    let fold_res = args.into_iter().fold(Ok(Expression::At(Atom::Int(0))), |acc, arg | {
-        match acc {
-            Err(err) => { Err(err) }
-            Ok(Expression::At(Atom::Int(acc_val))) => {
-                match arg {
-                    Expression::At(atom) => {
-                        match atom {
-                            Atom::Int(atom_val) => {
-                                Ok(Expression::At(Atom::Int(acc_val + atom_val)))
-                            }
-                            _ => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
-                        }
-                    }
-                    _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
-                }
+pub fn sum2(args: Vec<Expression>) -> EvalResult {
+    let mut acc = 0;
+    for arg in args {
+        if let Expression::At(atom) = arg {
+            if let Atom::Int(value) = atom {
+                acc += value
+            } else {
+                return Err(EvaluationError::WrongType(
+                    "atom but not integer".parse().unwrap(),
+                ));
             }
-            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+        } else {
+            return Err(EvaluationError::WrongType("not atom".parse().unwrap()));
         }
-    });
-    fold_res
+    }
+    Ok(Expression::At(Atom::Int(acc)))
+}
+
+pub fn sub2(args: Vec<Expression>) -> EvalResult {
+    let mut first_value = true;
+    let mut sbb = 0;
+    for arg in args {
+        if let Expression::At(atom) = arg {
+            if let Atom::Int(value) = atom {
+                sbb = if first_value {
+                    first_value = false;
+                    value
+                } else {
+                    sbb - value
+                }
+            } else {
+                return Err(EvaluationError::WrongType(
+                    "atom but not integer".parse().unwrap(),
+                ));
+            }
+        } else {
+            return Err(EvaluationError::WrongType("not atom".parse().unwrap()));
+        }
+    }
+    Ok(Expression::At(Atom::Int(sbb)))
+}
+
+pub fn mult2(args: Vec<Expression>) -> EvalResult {
+    let mut mtt = 1;
+    for arg in args {
+        if let Expression::At(atom) = arg {
+            if let Atom::Int(value) = atom {
+                mtt *= value;
+            } else {
+                return Err(EvaluationError::WrongType(
+                    "atom but not integer".parse().unwrap(),
+                ));
+            }
+        } else {
+            return Err(EvaluationError::WrongType("not atom".parse().unwrap()));
+        }
+    }
+    Ok(Expression::At(Atom::Int(mtt)))
+}
+
+pub fn div2(args: Vec<Expression>) -> EvalResult {
+    let mut first_value = true;
+    let mut dvv = 0;
+    for arg in args {
+        if let Expression::At(atom) = arg {
+            if let Atom::Int(value) = atom {
+                if value == 0 {
+                    return Err(EvaluationError::DivideByZero);
+                }
+                dvv = if first_value {
+                    first_value = false;
+                    value
+                } else {
+                    dvv / value
+                }
+            } else {
+                return Err(EvaluationError::WrongType(
+                    "atom but not integer".parse().unwrap(),
+                ));
+            }
+        } else {
+            return Err(EvaluationError::WrongType("not atom".parse().unwrap()));
+        }
+    }
+    Ok(Expression::At(Atom::Int(dvv)))
+}
+
+pub fn sum(args: Vec<Expression>) -> EvalResult {
+    args.into_iter()
+        .fold(Ok(Expression::At(Atom::Int(0))), |acc, arg| match acc {
+            Err(err) => Err(err),
+            Ok(Expression::At(Atom::Int(acc_val))) => match arg {
+                Expression::At(atom) => match atom {
+                    Atom::Int(atom_val) => Ok(Expression::At(Atom::Int(acc_val + atom_val))),
+                    _ => Err(EvaluationError::WrongType(
+                        "atom but not integer".parse().unwrap(),
+                    )),
+                },
+                _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
+            },
+            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
+        })
 }
 
 pub fn div(args: Vec<Expression>) -> EvalResult {
-    let first_elem = args[0].clone();
-    let fold_res = args.into_iter().fold(Ok(first_elem), |acc, arg | {
-        match acc {
-            Err(err) => { Err(err) }
-            Ok(Expression::At(Atom::Int(acc_val))) => {
-                match arg {
-                    Expression::At(atom) => {
-                        match atom {
-                            Atom::Int(atom_val) => {
-                                if atom_val == 0 { Err(EvaluationError::DivideByZero) }
-                                else { Ok(Expression::At(Atom::Int(acc_val / atom_val))) }
+    if let Expression::At(Atom::Int(first_elem)) = args[0] {
+        let fold_res = args.into_iter().fold(
+            Ok(Expression::At(Atom::Int(first_elem))),
+            |acc, arg| match acc {
+                Err(err) => Err(err),
+                Ok(Expression::At(Atom::Int(acc_val))) => match arg {
+                    Expression::At(atom) => match atom {
+                        Atom::Int(atom_val) => {
+                            if atom_val == 0 {
+                                Err(EvaluationError::DivideByZero)
+                            } else {
+                                Ok(Expression::At(Atom::Int(acc_val / atom_val)))
                             }
-                            _ => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
                         }
-                    }
-                    _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
-                }
-            }
-            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
-        }
-    });
-    fold_res
+                        _ => Err(EvaluationError::WrongType(
+                            "atom but not integer".parse().unwrap(),
+                        )),
+                    },
+                    _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
+                },
+                _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
+            },
+        );
+        fold_res
+    } else {
+        println!("FUCK YOU BOAH");
+        Err(EvaluationError::DivideByZero)
+    }
 }

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,5 +1,5 @@
-use parser::EvalResult;
-use parser::{Atom, EvaluationError, Expression};
+use parser::{Atom, Expression};
+use eval::{EvaluationError,EvalResult};
 
 pub fn neg(args: Vec<Expression>) -> EvalResult {
     let args_amount = args.len();
@@ -18,49 +18,7 @@ pub fn neg(args: Vec<Expression>) -> EvalResult {
     }
 }
 
-pub fn sum2(args: Vec<Expression>) -> EvalResult {
-    let mut acc = 0;
-    for arg in args {
-        if let Expression::At(atom) = arg {
-            if let Atom::Int(value) = atom {
-                acc += value
-            } else {
-                return Err(EvaluationError::WrongType(
-                    "atom but not integer".parse().unwrap(),
-                ));
-            }
-        } else {
-            return Err(EvaluationError::WrongType("not atom".parse().unwrap()));
-        }
-    }
-    Ok(Expression::At(Atom::Int(acc)))
-}
-
-pub fn sub2(args: Vec<Expression>) -> EvalResult {
-    let mut first_value = true;
-    let mut sbb = 0;
-    for arg in args {
-        if let Expression::At(atom) = arg {
-            if let Atom::Int(value) = atom {
-                sbb = if first_value {
-                    first_value = false;
-                    value
-                } else {
-                    sbb - value
-                }
-            } else {
-                return Err(EvaluationError::WrongType(
-                    "atom but not integer".parse().unwrap(),
-                ));
-            }
-        } else {
-            return Err(EvaluationError::WrongType("not atom".parse().unwrap()));
-        }
-    }
-    Ok(Expression::At(Atom::Int(sbb)))
-}
-
-pub fn mult2(args: Vec<Expression>) -> EvalResult {
+pub fn mul(args: Vec<Expression>) -> EvalResult {
     let mut mtt = 1;
     for arg in args {
         if let Expression::At(atom) = arg {
@@ -78,7 +36,7 @@ pub fn mult2(args: Vec<Expression>) -> EvalResult {
     Ok(Expression::At(Atom::Int(mtt)))
 }
 
-pub fn div2(args: Vec<Expression>) -> EvalResult {
+pub fn div(args: Vec<Expression>) -> EvalResult {
     let mut first_value = true;
     let mut dvv = 0;
     for arg in args {
@@ -122,33 +80,3 @@ pub fn sum(args: Vec<Expression>) -> EvalResult {
         })
 }
 
-pub fn div(args: Vec<Expression>) -> EvalResult {
-    if let Expression::At(Atom::Int(first_elem)) = args[0] {
-        let fold_res = args.into_iter().fold(
-            Ok(Expression::At(Atom::Int(first_elem))),
-            |acc, arg| match acc {
-                Err(err) => Err(err),
-                Ok(Expression::At(Atom::Int(acc_val))) => match arg {
-                    Expression::At(atom) => match atom {
-                        Atom::Int(atom_val) => {
-                            if atom_val == 0 {
-                                Err(EvaluationError::DivideByZero)
-                            } else {
-                                Ok(Expression::At(Atom::Int(acc_val / atom_val)))
-                            }
-                        }
-                        _ => Err(EvaluationError::WrongType(
-                            "atom but not integer".parse().unwrap(),
-                        )),
-                    },
-                    _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
-                },
-                _ => Err(EvaluationError::WrongType("not atom".parse().unwrap())),
-            },
-        );
-        fold_res
-    } else {
-        println!("FUCK YOU BOAH");
-        Err(EvaluationError::DivideByZero)
-    }
-}

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,8 +1,24 @@
 use parser::{Expression, Atom, EvaluationError};
 use parser::EvalResult;
 
+pub fn neg(args: Vec<Expression>) -> EvalResult {
+    let args_amount = args.len();
+    if args_amount != 1 {
+        Err(EvaluationError::WrongArity(1, args_amount as i64))
+    } else {
+        match &args[0] {
+            Expression::At(atom) => {
+                match atom {
+                    Atom::Int(i) =>{ Ok(Expression::At(Atom::Int(i * (-1)))) }
+                    _ => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
+                }
+            }
+            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+        }
+    }
+}
+
 pub fn sum(args: Vec<Expression>) -> EvalResult {
-    // TODO: Upgrade to Nightly Rust to use fold_first
     let fold_res = args.into_iter().fold(Ok(Expression::At(Atom::Int(0))), |acc, arg | {
         match acc {
             Err(err) => { Err(err) }
@@ -13,13 +29,38 @@ pub fn sum(args: Vec<Expression>) -> EvalResult {
                             Atom::Int(atom_val) => {
                                 Ok(Expression::At(Atom::Int(acc_val + atom_val)))
                             }
-                            _NotInt => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
+                            _ => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
                         }
                     }
-                    _NotAtom => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+                    _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
                 }
             }
-            _NotAccAtom_ImpossibleWhichIsWhyWeNeedFoldFirst => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+        }
+    });
+    fold_res
+}
+
+pub fn div(args: Vec<Expression>) -> EvalResult {
+    let first_elem = args[0].clone();
+    let fold_res = args.into_iter().fold(Ok(first_elem), |acc, arg | {
+        match acc {
+            Err(err) => { Err(err) }
+            Ok(Expression::At(Atom::Int(acc_val))) => {
+                match arg {
+                    Expression::At(atom) => {
+                        match atom {
+                            Atom::Int(atom_val) => {
+                                if atom_val == 0 { Err(EvaluationError::DivideByZero) }
+                                else { Ok(Expression::At(Atom::Int(acc_val / atom_val))) }
+                            }
+                            _ => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
+                        }
+                    }
+                    _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+                }
+            }
+            _ => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
         }
     });
     fold_res

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,15 +1,26 @@
-pub fn sum(x: i64, y: i64) -> i64 {
-    x + y
-}
+use parser::{Expression, Atom, EvaluationError};
+use parser::EvalResult;
 
-pub fn sub(x: i64, y: i64) -> i64 {
-    x - y
-}
-
-pub fn mul(x: i64, y: i64) -> i64 {
-    x * y
-}
-
-pub fn div(x: i64, y: i64) -> i64 {
-    x / y
+pub fn sum(args: Vec<Expression>) -> EvalResult {
+    // TODO: Upgrade to Nightly Rust to use fold_first
+    let fold_res = args.into_iter().fold(Ok(Expression::At(Atom::Int(0))), |acc, arg | {
+        match acc {
+            Err(err) => { Err(err) }
+            Ok(Expression::At(Atom::Int(acc_val))) => {
+                match arg {
+                    Expression::At(atom) => {
+                        match atom {
+                            Atom::Int(atom_val) => {
+                                Ok(Expression::At(Atom::Int(acc_val + atom_val)))
+                            }
+                            _NotInt => Err(EvaluationError::WrongType("atom but not integer".parse().unwrap()))
+                        }
+                    }
+                    _NotAtom => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+                }
+            }
+            _NotAccAtom_ImpossibleWhichIsWhyWeNeedFoldFirst => Err(EvaluationError::WrongType("not atom".parse().unwrap()))
+        }
+    });
+    fold_res
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,0 +1,64 @@
+use parser::{Expression, Atom};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub enum EvaluationError {
+    DivideByZero,
+    FunctionNotFound,
+    NotAFunction,
+    WrongType(String),
+    WrongArity(i64, i64) // (Expected, Received)
+}
+
+
+/* TODO: Discover how to parametrize the Ok return value
+   E.g.:  When evaluation of summation goes OK, the result is not
+   just any Expression, it is in fact an Expression that contains an integer.
+   Any value of that return Expression is going to successfully pattern match on
+   the pattern
+   Expression::At(Atom::Int(val))
+
+   How do we get this guarantee on the type level? */
+pub type EvalResult = Result<Expression, EvaluationError>;
+
+
+fn map_m(maybes: Vec<EvalResult>) -> Result<Vec<Expression>, EvalResult> {
+    let mut to_return = Vec::new();
+    for eval_res in maybes {
+        match eval_res {
+            Err(_) =>{ return Err(eval_res) }
+            Ok(expr) => { to_return.push(expr) }
+        }
+    }
+    Ok(to_return)
+}
+
+fn eval_expression(expr: Expression, vars: &HashMap<String, fn(Vec<Expression>) -> EvalResult>) -> EvalResult {
+    match expr {
+        Expression::At(_) => { Ok(expr) }
+        Expression::Expr(op, args) => {
+            let evaled_fn_symbol = eval_expression(*op, vars)?;
+            let evaled_args = args.into_iter().map(|x| eval_expression(x, vars));
+            let try_correct_evaled_args = map_m(evaled_args.collect());
+            match try_correct_evaled_args {
+                Err(err) => { err }
+                Ok(evaled_args) => {
+                    match evaled_fn_symbol {
+                        Expression::At(Atom::Symbol(sym)) => {
+                            match vars.get(&sym) {
+                                None => { Err(EvaluationError::FunctionNotFound) }
+                                Some(rust_fn) => { rust_fn(evaled_args) }
+                            }
+                        }
+                        _ => {Err(EvaluationError::NotAFunction)}
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn eval(expr: Expression, vars: &HashMap<String, fn(Vec<Expression>) -> EvalResult>) -> String {
+    let evaled_expr = eval_expression(expr, vars);
+    format!("{:?}", evaled_expr)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate nom;
 
 use std::io::{self, Write};
 use nom::lib::std::collections::HashMap;
+use parser::{Expression, EvalResult};
 
 mod parser;
 mod built_in;
@@ -31,18 +32,15 @@ fn main() {
 
         /* Construct built-in function table 
            TODO: Move construction to built_in module itself */
-        let mut built_ins = HashMap::<String, fn(i64, i64) -> i64>::new();
+        let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult>::new();
         built_ins.insert("+".to_string(), built_in::sum);
-        built_ins.insert("-".to_string(), built_in::sub);
-        built_ins.insert("*".to_string(), built_in::mul);
-        built_ins.insert("/".to_string(), built_in::div);
 
         let immut_built_ins = built_ins.clone();
 
         /* Print user input line (just the parsed tree for now) */
         match parsed_input_expression {
             Ok((_, expr)) => {
-                println!("{}", parser::eval(expr, &immut_built_ins));
+                println!("eval: {}", parser::eval(expr, &immut_built_ins));
             }
             Err(_) => {
                 println!("Fuck you, boah")

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,10 @@ fn main() {
         /* Construct built-in function table 
            TODO: Move construction to built_in module itself */
         let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult>::new();
-        built_ins.insert("+".to_string(), built_in::sum);
-        built_ins.insert("/".to_string(), built_in::div);
+        built_ins.insert("+".to_string(), built_in::sum2);
+        built_ins.insert("-".to_string(), built_in::sub2);
+        built_ins.insert("*".to_string(), built_in::mult2);
+        built_ins.insert("/".to_string(), built_in::div2);
         built_ins.insert("neg".to_string(), built_in::neg);
 
         let immut_built_ins = built_ins.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,10 @@ extern crate nom;
 
 use std::io::{self, Write};
 use nom::lib::std::collections::HashMap;
-use parser::{Expression, EvalResult};
-
+use parser::{Expression};
+use eval::{EvalResult};
 mod parser;
+mod eval;
 mod built_in;
 
 fn main() {
@@ -33,10 +34,9 @@ fn main() {
         /* Construct built-in function table 
            TODO: Move construction to built_in module itself */
         let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult>::new();
-        built_ins.insert("+".to_string(), built_in::sum2);
-        built_ins.insert("-".to_string(), built_in::sub2);
-        built_ins.insert("*".to_string(), built_in::mult2);
-        built_ins.insert("/".to_string(), built_in::div2);
+        built_ins.insert("+".to_string(), built_in::sum);
+        built_ins.insert("*".to_string(), built_in::mul);
+        built_ins.insert("/".to_string(), built_in::div);
         built_ins.insert("neg".to_string(), built_in::neg);
 
         let immut_built_ins = built_ins.clone();
@@ -44,7 +44,7 @@ fn main() {
         /* Print user input line (just the parsed tree for now) */
         match parsed_input_expression {
             Ok((_, expr)) => {
-                println!("eval: {}", parser::eval(expr, &immut_built_ins));
+                println!("eval: {}", eval::eval(expr, &immut_built_ins));
             }
             Err(_) => {
                 println!("Fuck you, boah")

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ fn main() {
            TODO: Move construction to built_in module itself */
         let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult>::new();
         built_ins.insert("+".to_string(), built_in::sum);
+        built_ins.insert("/".to_string(), built_in::div);
+        built_ins.insert("neg".to_string(), built_in::neg);
 
         let immut_built_ins = built_ins.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 extern crate nom;
+
 use std::io::{self, Write};
+use nom::lib::std::collections::HashMap;
+
 mod parser;
+mod built_in;
 
 fn main() {
     /* Initial prompt and shit */
@@ -25,10 +29,20 @@ fn main() {
         let to_parse = x.to_owned();
         let parsed_input_expression = parser::parse(&to_parse);
 
+        /* Construct built-in function table 
+           TODO: Move construction to built_in module itself */
+        let mut built_ins = HashMap::<String, fn(i64, i64) -> i64>::new();
+        built_ins.insert("+".to_string(), built_in::sum);
+        built_ins.insert("-".to_string(), built_in::sub);
+        built_ins.insert("*".to_string(), built_in::mul);
+        built_ins.insert("/".to_string(), built_in::div);
+
+        let immut_built_ins = built_ins.clone();
+
         /* Print user input line (just the parsed tree for now) */
         match parsed_input_expression {
             Ok((_, expr)) => {
-                println!("{}", parser::eval(expr));
+                println!("{}", parser::eval(expr, &immut_built_ins));
             }
             Err(_) => {
                 println!("Fuck you, boah")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,6 +20,7 @@ pub enum EvaluationError {
     FunctionNotFound,
     NotAFunction,
     WrongType(String),
+    WrongArity(i64, i64) // (Expected, Received)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Basically chapters 7 through 9 of buildyourownlisp.com.

We handle evaluation error in a hopefully parametrizable EvalResult. We say parametrizable because we know the kind of expressions certain built-in functions return: arithmetic returns numbers for instance, and can only result in a certain number of errors. One of the TODOs is about this.

The structure for all evaluation errors is within this PR, and also for all future built-in functionality (of which we really only plan to implement `def` and `fn`).