### PR TITLE
Function calls, arrays and environment

### DIFF
--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,7 +1,7 @@
 use types::{Expression, EvaluationError, EvalResult, Atom};
 
-// Built-in fns
-pub fn neg(args: Vec<Expression>) -> EvalResult {
+// TODO: Built-in fns estão pedreiras
+pub fn neg(args: Vec<Expression>) -> EvalResult<Expression> {
     let args_amount = args.len();
     if args_amount != 1 {
         Err(EvaluationError::WrongArity(1, args_amount as i64))
@@ -18,7 +18,7 @@ pub fn neg(args: Vec<Expression>) -> EvalResult {
     }
 }
 
-pub fn mul(args: Vec<Expression>) -> EvalResult {
+pub fn mul(args: Vec<Expression>) -> EvalResult<Expression> {
     let mut mtt = 1;
     for arg in args {
         if let Expression::At(atom) = arg {
@@ -36,7 +36,7 @@ pub fn mul(args: Vec<Expression>) -> EvalResult {
     Ok(Expression::At(Atom::Int(mtt)))
 }
 
-pub fn div(args: Vec<Expression>) -> EvalResult {
+pub fn div(args: Vec<Expression>) -> EvalResult<Expression> {
     let mut first_value = true;
     let mut dvv = 0;
     for arg in args {
@@ -63,7 +63,7 @@ pub fn div(args: Vec<Expression>) -> EvalResult {
     Ok(Expression::At(Atom::Int(dvv)))
 }
 
-pub fn sum(args: Vec<Expression>) -> EvalResult {
+pub fn sum(args: Vec<Expression>) -> EvalResult<Expression> {
     args.into_iter()
         .fold(Ok(Expression::At(Atom::Int(0))), |acc, arg| match acc {
             Err(err) => Err(err),

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,6 +1,6 @@
 use types::{Expression, EvaluationError, EvalResult, Atom};
 
-// Built-in fns (temp)
+// Built-in fns
 pub fn neg(args: Vec<Expression>) -> EvalResult {
     let args_amount = args.len();
     if args_amount != 1 {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
-use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment};
-use types::Expression::{Expr, At};
+use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment, FunctionType};
+use types::Expression::{List, At};
 
-fn quote_expr(to_quote: Vec<Expression>) -> EvalResult {
+fn quote_expr(to_quote: Vec<Expression>) -> EvalResult<Expression> {
     if to_quote.len() == 1 {
         Ok(to_quote[0].clone())
     } else {
@@ -11,7 +11,7 @@ fn quote_expr(to_quote: Vec<Expression>) -> EvalResult {
 
 }
 
-fn if_expr(args: Vec<Expression>, env: &Environment) -> EvalResult {
+fn if_expr(args: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
     let is_truthy: fn(Expression) -> bool = |expr|
         match expr {
             Expression::At(Atom::Bool(false)) => false,
@@ -33,7 +33,8 @@ fn if_expr(args: Vec<Expression>, env: &Environment) -> EvalResult {
     }
 }
 
-fn map_m(maybes: Vec<EvalResult>) -> Result<Vec<Expression>, EvalResult> {
+// TODO 4: Map_m específico nojento
+fn map_m(maybes: Vec<EvalResult<Expression>>) -> Result<Vec<Expression>, EvalResult<Expression>> {
     let mut to_return = Vec::new();
     for eval_res in maybes {
         match eval_res {
@@ -44,18 +45,19 @@ fn map_m(maybes: Vec<EvalResult>) -> Result<Vec<Expression>, EvalResult> {
     Ok(to_return)
 }
 
-fn lambda (args: Vec<Expression>) -> EvalResult {
+// TODO: Horrível
+fn lambda (args: Vec<Expression>) -> EvalResult<Expression> {
     if args.len() == 2 {
         match args[0].clone() {
             Expression::Array(arr) => {
-                let mut arr_iterator = arr.into_iter();
+                let mut arr_iterator = arr.clone().into_iter();
                 if arr_iterator.all(|x| match x { Expression::At(Atom::Symbol(_)) => true, _ => false}) {
-                    let arr_atoms = arr_iterator.map(|x |
+                    let arr_atoms = arr.into_iter().map(|x |
                         match x {
                             Expression::At(Atom::Symbol(s)) => Atom::Symbol(s),
                             _ => panic!("acho que impossivel")
                         });
-                    Ok(Expression::Lambda(arr_atoms.collect(), Box::from(args[1].clone())))
+                    Ok(Expression::Function(FunctionType::Lambda(arr_atoms.collect(), Box::from(args[1].clone()))))
                 } else {
                     Err(EvaluationError::WrongType("not all args were symbols".parse().unwrap()))
                 }
@@ -67,17 +69,46 @@ fn lambda (args: Vec<Expression>) -> EvalResult {
     }
 }
 
-fn call_function(called_functon: Expression, args_fn_is_receiving: Vec<Expression>, env: &Environment) -> EvalResult {
-    match called_functon {
-        Expression::Lambda(params_fn_takes, body) => {
-            Ok(Expression::At(Atom::Int(1)))
-        },
-        _ => Err(EvaluationError::NotSpecialFormOrFunction) // TODO Should be impossible. How to express with types?
+// TODO 2: Horrível. Fuck for loops
+fn substitute(params_fn_takes: Vec<Atom>, args_fn_is_receiving: Vec<Expression>, env: &Environment) -> EvalResult<Environment> {
+    let mut new_environment = env.clone(); // TODO: Don't clone whole environment for each function call
+    let two_together = params_fn_takes.into_iter().zip(args_fn_is_receiving);
+    // TODO: disgusting side-effectful map, should be a mapM_
+    // let res = two_together.map(|(param,arg)| {
+    //     match param {
+    //         Atom::Symbol(sym) => Ok(new_environment.vars.insert(sym, arg)),
+    //         _ => Err(EvaluationError::UnknownBinding("can only bind to symbols".parse().unwrap()))
+    //     }
+    // });
+    for (param, arg) in two_together {
+        match param {
+            Atom::Symbol(sym) => new_environment.vars.insert(sym, arg),
+            _ => return Err(EvaluationError::UnknownBinding("can only bind to symbols".parse().unwrap()))
+        };
+    }
+    Ok(new_environment)
+}
+
+// TODO 3: Usar um map_m sério
+fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
+    let evaled_args = map_m(args_fn_is_receiving.into_iter().map(|x| eval_expression(x, env)).collect());
+
+    match evaled_args {
+        Ok(correctly_evaled_args) => {
+            match called_fn {
+                FunctionType::Lambda(params_fn_takes, body) => {
+                    let local_env = substitute(params_fn_takes, correctly_evaled_args, env)?;
+                    eval_expression(*body, &local_env)
+                },
+                FunctionType::BuiltIn(built_in) => built_in(correctly_evaled_args),
+            }
+        }
+        Err(err) => err
     }
 }
 
 
-fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &Environment) -> EvalResult {
+fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
     match special_form {
         SpecialForm::Quote => quote_expr(args),
         SpecialForm::If => if_expr(args, env),
@@ -89,32 +120,30 @@ fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &Env
     }
 }
 
-fn lookup_symbol(sym: String, env: &Environment) -> EvalResult {
+fn lookup_symbol(sym: String, env: &Environment) -> EvalResult<Expression> {
     if let Some(special_form_type) = env.special_forms.get(&sym) {
         Ok(Expression::SpecialForm(special_form_type.clone()))
     } else if let Some(built_in) = env.built_in_fns.get(&sym) {
-        Ok(Expression::BuiltIn(*built_in))
+        Ok(Expression::Function(FunctionType::BuiltIn(*built_in)))
     } else if let Some(expr) = env.vars.get(&sym) {
         Ok(expr.clone())
     } else {
-        Err(EvaluationError::SymbolNotFound)
+        Err(EvaluationError::SymbolNotFound(sym))
     }
 }
 
-fn eval_expression(expr: Expression, env: &Environment) -> EvalResult {
+fn eval_expression(expr: Expression, env: &Environment) -> EvalResult<Expression> {
     match expr {
         Expression::At(Atom::Symbol(sym)) => lookup_symbol(sym, env),
         Expression::At(_) => Ok(expr),
-        Expression::BuiltIn(_) => Ok(expr),
-        Expression::Lambda(_, _) => Ok(expr),
-        Expression::Array(_) => Ok(expr),
-        Expression::SpecialForm(_) => Err(EvaluationError::SpecialFormOutOfContext),
-        Expression::Expr(op, args) => {
+        Expression::Function(_) => Ok(expr),
+        Expression::SpecialForm(_) => Err(EvaluationError::SpecialFormOutOfContext), // TODO: Impossible due to lookup
+        Expression::Array(_) => Ok(expr), // TODO: Has to eval elements
+        Expression::List(op, args) => {
             let caller = eval_expression(*op, env)?;
             match caller {
                 Expression::SpecialForm(special_form_type) => call_special_form(special_form_type.clone(), args, &env),
-                Expression::BuiltIn(built_in) => built_in(args), // TODO: Built-ins have to evaluate their arguments beforehand too
-                Expression::Lambda(params, body) => call_function(Expression::Lambda(params.clone(), body.clone()), args, &env),
+                Expression::Function(fn_type) => call_function(fn_type, args, &env),
                 _ => Err(EvaluationError::NotSpecialFormOrFunction)
             }
         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use types::{Expression,EvaluationError,ResolvedSymbol,EvalResult,SpecialForm,Atom};
+use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment};
 use types::Expression::{Expr, At};
 
 fn quote_expr(to_quote: Vec<Expression>) -> EvalResult {
@@ -11,7 +11,7 @@ fn quote_expr(to_quote: Vec<Expression>) -> EvalResult {
 
 }
 
-fn if_expr(args: Vec<Expression>, vars: &HashMap<String, ResolvedSymbol>) -> EvalResult {
+fn if_expr(args: Vec<Expression>, env: &Environment) -> EvalResult {
     let is_truthy: fn(Expression) -> bool = |expr|
         match expr {
             Expression::At(Atom::Bool(false)) => false,
@@ -20,11 +20,11 @@ fn if_expr(args: Vec<Expression>, vars: &HashMap<String, ResolvedSymbol>) -> Eva
         };
 
     if args.len() == 3 || args.len() == 2 {
-        let evaled_cond = eval_expression(args[0].clone(), vars)?;
+        let evaled_cond = eval_expression(args[0].clone(), env)?;
         if is_truthy(evaled_cond) {
-            eval_expression(args[1].clone(), vars)
+            eval_expression(args[1].clone(), env)
         } else if args.len() == 3 {
-            eval_expression(args[2].clone(), vars)
+            eval_expression(args[2].clone(), env)
         } else {
             Ok(Expression::At(Atom::Nil))
         }
@@ -44,50 +44,84 @@ fn map_m(maybes: Vec<EvalResult>) -> Result<Vec<Expression>, EvalResult> {
     Ok(to_return)
 }
 
-fn call_function(called_functon: Expression, args_fn_is_receiving: Vec<Expression>, vars: &HashMap<String, ResolvedSymbol>) -> EvalResult {
+fn lambda (args: Vec<Expression>) -> EvalResult {
+    if args.len() == 2 {
+        match args[0].clone() {
+            Expression::Array(arr) => {
+                let mut arr_iterator = arr.into_iter();
+                if arr_iterator.all(|x| match x { Expression::At(Atom::Symbol(_)) => true, _ => false}) {
+                    let arr_atoms = arr_iterator.map(|x |
+                        match x {
+                            Expression::At(Atom::Symbol(s)) => Atom::Symbol(s),
+                            _ => panic!("acho que impossivel")
+                        });
+                    Ok(Expression::Lambda(arr_atoms.collect(), Box::from(args[1].clone())))
+                } else {
+                    Err(EvaluationError::WrongType("not all args were symbols".parse().unwrap()))
+                }
+            }
+            _ => Err(EvaluationError::WrongType("arguments to fn must be array".parse().unwrap()))
+        }
+    } else {
+        Err(EvaluationError::WrongArity(2, args.len() as i64))
+    }
+}
+
+fn call_function(called_functon: Expression, args_fn_is_receiving: Vec<Expression>, env: &Environment) -> EvalResult {
     match called_functon {
-        Expression::Function(params_fn_takes, body) => Ok(Expression::At(Atom::Int(1))),
-        _ => Err(EvaluationError::NotAFunction)
+        Expression::Lambda(params_fn_takes, body) => {
+            Ok(Expression::At(Atom::Int(1)))
+        },
+        _ => Err(EvaluationError::NotSpecialFormOrFunction) // TODO Should be impossible. How to express with types?
     }
 }
 
 
-fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, vars: &HashMap<String, ResolvedSymbol>) -> EvalResult {
+fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &Environment) -> EvalResult {
     match special_form {
         SpecialForm::Quote => quote_expr(args),
-        SpecialForm::If => if_expr(args, vars),
+        SpecialForm::If => if_expr(args, env),
+        SpecialForm::Fn => lambda(args),
         _ => { panic! ("Como vc achou um special form sem que ele exista? Lixo")}
         /* TODO: Implement other special forms
-        SpecialForm::Fn(args, body) => { Ok(*my_boxed_expr) }
         SpecialForm::Def(name, value) => { Ok(*my_boxed_expr) }
         */
     }
 }
 
+fn lookup_symbol(sym: String, env: &Environment) -> EvalResult {
+    if let Some(special_form_type) = env.special_forms.get(&sym) {
+        Ok(Expression::SpecialForm(special_form_type.clone()))
+    } else if let Some(built_in) = env.built_in_fns.get(&sym) {
+        Ok(Expression::BuiltIn(*built_in))
+    } else if let Some(expr) = env.vars.get(&sym) {
+        Ok(expr.clone())
+    } else {
+        Err(EvaluationError::SymbolNotFound)
+    }
+}
 
-fn eval_expression(expr: Expression, vars: &HashMap<String, ResolvedSymbol>) -> EvalResult {
+fn eval_expression(expr: Expression, env: &Environment) -> EvalResult {
     match expr {
+        Expression::At(Atom::Symbol(sym)) => lookup_symbol(sym, env),
         Expression::At(_) => Ok(expr),
-        Expression::Function(_,_) => Ok(expr),
+        Expression::BuiltIn(_) => Ok(expr),
+        Expression::Lambda(_, _) => Ok(expr),
+        Expression::Array(_) => Ok(expr),
+        Expression::SpecialForm(_) => Err(EvaluationError::SpecialFormOutOfContext),
         Expression::Expr(op, args) => {
-            let caller = eval_expression(*op, vars)?;
+            let caller = eval_expression(*op, env)?;
             match caller {
-                Expression::At(Atom::Symbol(sym)) => {
-                    let resolved_symbol = vars.get(&sym);
-                    match resolved_symbol {
-                        Some(ResolvedSymbol::SpecialF(special_form_type)) => call_special_form(special_form_type.clone(), args, vars),
-                        Some(ResolvedSymbol::Value(Expression::Function(params, body))) => call_function(Expression::Function(params.clone(), body.clone()), args, vars),
-                        _ => Err(EvaluationError::SymbolNotFound)
-                    }
-                }
-                Expression::Function(params, body) => call_function(Expression::Function(params.clone(), body.clone()), args, vars),
-                _ => Err(EvaluationError::NotAFunction)
+                Expression::SpecialForm(special_form_type) => call_special_form(special_form_type.clone(), args, &env),
+                Expression::BuiltIn(built_in) => built_in(args), // TODO: Built-ins have to evaluate their arguments beforehand too
+                Expression::Lambda(params, body) => call_function(Expression::Lambda(params.clone(), body.clone()), args, &env),
+                _ => Err(EvaluationError::NotSpecialFormOrFunction)
             }
         }
     }
 }
 
-pub fn eval(expr: Expression, vars: &HashMap<String, ResolvedSymbol>) -> String {
-    let evaled_expr = eval_expression(expr, vars);
+pub fn eval(expr: Expression, env: &Environment) -> String {
+    let evaled_expr = eval_expression(expr, env);
     format!("{:?}", evaled_expr)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,20 +23,21 @@ fn main() {
         let mut x = String::new();
 
         /* Read user input line */
+        /* TODO: voltar o cursor no REPL. Ngm merece ^[[D */
         io::stdin().read_line(&mut x).expect("Failed to read line");
 
         /* Record input */
         input_history.push(x.clone());
 
-        /*  TOUNDERSTAND: Why does "let parsed_input_expression = parser::parse(&x.to_owned());" not work?
-            Parse input into expression tree */
+        /*  TODO; UNDERSTAND: Why does "let parsed_input_expression = parser::parse(&x.to_owned());" not work? */
+        /*  Parse input into expression tree */
         let to_parse = x.to_owned();
         let parsed_input_expression = parser::parse(&to_parse);
 
         /* Construct built-in function table 
            TODO: Move construction to built_in module itself */
         let mut special_forms = HashMap::<String, SpecialForm>::new();
-        let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult>::new();
+        let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult<Expression>>::new();
         let mut vars = HashMap::<String, Expression>::new();
         built_ins.insert("+".to_string(), built_in::sum);
         built_ins.insert("*".to_string(), built_in::mul);
@@ -46,8 +47,6 @@ fn main() {
         special_forms.insert("if".to_string(), SpecialForm::If);
         special_forms.insert("fn".to_string(), SpecialForm::Fn);
         vars.insert("variavel-qualquer".to_string(), Expression::At(Atom::Int(11)));
-
-        let immut_built_ins = special_forms.clone();
 
         let env = Environment {
             special_forms: special_forms,
@@ -61,8 +60,8 @@ fn main() {
             Ok((_, expr)) => {
                 println!("eval: {}", eval::eval(expr, &env));
             }
-            Err(_) => {
-                println!("Fuck you, boah")
+            Err(parser_error) => {
+                println!("Fuck you, boah: {:?}", parser_error)
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+// TODO zão: still need to improve parser by using `delim` and other pure nom constructs.
+
 use nom::{branch::alt,
           bytes::complete::{take_while, take_while1, tag, take},
           character::{is_space, is_digit},
@@ -56,13 +58,13 @@ fn parse_bool(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorK
     Ok((rest, Expression::At(Atom::Bool(from_u8_array_to_bool(boolean)))))
 }
 
+/* TODO: This doesn't work! Has to take into account spaces or ')' after the literal*/
 fn parse_nil(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
     let (rest, _spaces) = take_while(is_space_lisp)(i)?;
     let (rest, _nil) = tag("nil")(rest)?;
 
     Ok((rest, Expression::At(Atom::Nil)))
 }
-/* ------------------------------------------------------------- */
 
 fn parse_atom(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
     alt((parse_num, parse_char, parse_bool, parse_nil, parse_symbol))(i)
@@ -118,7 +120,7 @@ fn parse_expression(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::
     let (new_rest, _end_spaces) = take_while(is_space_lisp)(new_rest)?;
     let (newest_rest, _paren2) = char(')')(new_rest)?;
 
-    Ok((newest_rest, Expression::Expr(Box::new(op_expression), args)))
+    Ok((newest_rest, Expression::List(Box::new(op_expression), args)))
 }
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,7 +15,7 @@ fn is_valid_symbol_char(c: u8) -> bool {
 }
 
 fn parse_expression_top_level(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
-    alt((parse_atom, parse_function, parse_expression))(i)
+    alt((parse_atom, parse_expression, parse_array))(i)
 }
 
 fn parse_num(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
@@ -68,28 +68,20 @@ fn parse_atom(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorK
     alt((parse_num, parse_char, parse_bool, parse_nil, parse_symbol))(i)
 }
 
-fn parse_function(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
-    let (rest, _spaces) = take_while(is_space_lisp)(i)?;
-    let (rest, _paren1) = char('(')(rest)?;
-    let (rest, _spaces) = take_while(is_space_lisp)(rest)?;
-    let (rest, _nil) = tag("fn")(rest)?;
-    let (rest, _spaces) = take_while(is_space_lisp)(rest)?;
+fn parse_array(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
+    let (rest, _first_spaces) = take_while(is_space_lisp)(i)?;
     let (rest, _bracket1) = char('[')(rest)?;
-    let (rest, _spaces) = take_while(is_space_lisp)(rest)?;
 
-    let mut args = Vec::new();
+    let mut array = Vec::new();
 
     let mut new_rest = rest;
     let mut should_continue = true;
     while should_continue {
-        let could_parse = parse_atom(new_rest);
+        let could_parse = parse_expression_top_level(new_rest);
         match could_parse {
-            Ok((other_new_rest, Expression::At(sym))) => {
-                args.push(sym);
+            Ok((other_new_rest, expr)) => {
+                array.push(expr);
                 new_rest = other_new_rest;
-            }
-            Ok(_) => {
-                panic!("sei la")
             }
             Err(_) => {
                 should_continue = false;
@@ -97,13 +89,9 @@ fn parse_function(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::Er
         }
     }
     let (new_rest, _end_spaces) = take_while(is_space_lisp)(new_rest)?;
-    let (new_rest, _bracket2) = char(']')(new_rest)?;
+    let (newest_rest, _paren2) = char(']')(new_rest)?;
 
-    let (new_rest, body) = parse_expression_top_level(new_rest)?;
-    let (new_rest, _end_spaces) = take_while(is_space_lisp)(new_rest)?;
-    let (new_rest, _paren2) = char(')')(new_rest)?;
-
-    Ok((new_rest, Expression::Function(args, Box::from(body))))
+    Ok((newest_rest, Expression::Array(array)))
 }
 
 fn parse_expression(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 #[derive(Debug, Clone)]
 
 /* TODO: Discover how to parametrize the our types.
@@ -24,18 +26,24 @@ pub enum Atom {
 pub enum Expression {
     At(Atom),
     Expr(Box<Expression>, Vec<Expression>), // TODO also: implement this as a linked list (which it kind of already is but very buffed)
-    Array(Vec<Expression>), // TODO: Implement Fn as a special form that validates its arguments
-    Function(Vec<Atom>, Box<Expression>)
+    Array(Vec<Expression>),
+    SpecialForm(SpecialForm),
+    /* TODO: Perhaps instead of having the two below, we could have a single "Function" enum that is either built-in
+    or is a lambda. In both cases they need to be aware of their `env`ironment, and need to evaluate the args before called. */
+    BuiltIn(fn(Vec<Expression>) -> EvalResult),
+    Lambda(Vec<Atom>, Box<Expression>)
+
 }
 
 #[derive(Debug)]
 pub enum EvaluationError {
     DivideByZero,
     SymbolNotFound,
-    NotAFunction,
+    NotSpecialFormOrFunction,
     Pending,
     WrongType(String),
     WrongArity(i64, i64), // (Expected, Received)
+    SpecialFormOutOfContext,
 }
 
 pub type EvalResult = Result<Expression, EvaluationError>;
@@ -53,9 +61,10 @@ pub enum SpecialForm {
     Def,
 }
 
-
 #[derive (Debug, Clone)]
-pub enum ResolvedSymbol {
-    Value(Expression),
-    SpecialF(SpecialForm),
+pub struct Environment {
+    pub special_forms: HashMap<String, SpecialForm>,
+    pub built_in_fns: HashMap<String, fn(Vec<Expression>) -> EvalResult>,
+    pub vars: HashMap<String, Expression>
 }
+

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
-
 /* TODO: Discover how to parametrize the our types.
    For example: an Expression::Function(vec, _) doesn't contain, in vec, just any atom.
    In fact its atoms should be Symbols that we can easily add to the fn's local environment.
@@ -14,6 +12,7 @@ use std::collections::HashMap;
    Expression::At(Atom::Int(val))
 
    How do we get this guarantee on the type level? */
+#[derive(Debug, Clone)]
 pub enum Atom {
     Int(i64),
     Char(char),
@@ -23,48 +22,48 @@ pub enum Atom {
 }
 
 #[derive(Debug, Clone)]
+pub enum FunctionType {
+    Lambda(Vec<Atom>, Box<Expression>),
+    BuiltIn(fn(Vec<Expression>) -> EvalResult<Expression>)
+}
+
+#[derive(Debug, Clone)]
 pub enum Expression {
     At(Atom),
-    Expr(Box<Expression>, Vec<Expression>), // TODO also: implement this as a linked list (which it kind of already is but very buffed)
+    List(Box<Expression>, Vec<Expression>), // TODO: implement this as a linked list (which it kind of already is but very buffed)
     Array(Vec<Expression>),
     SpecialForm(SpecialForm),
-    /* TODO: Perhaps instead of having the two below, we could have a single "Function" enum that is either built-in
-    or is a lambda. In both cases they need to be aware of their `env`ironment, and need to evaluate the args before called. */
-    BuiltIn(fn(Vec<Expression>) -> EvalResult),
-    Lambda(Vec<Atom>, Box<Expression>)
-
+    Function(FunctionType)
 }
 
 #[derive(Debug)]
 pub enum EvaluationError {
     DivideByZero,
-    SymbolNotFound,
+    SymbolNotFound(String),
     NotSpecialFormOrFunction,
     Pending,
     WrongType(String),
     WrongArity(i64, i64), // (Expected, Received)
     SpecialFormOutOfContext,
+    UnknownBinding(String)
 }
 
-pub type EvalResult = Result<Expression, EvaluationError>;
+pub type EvalResult<O> = Result<O, EvaluationError>;
 /* ------------------------------------------------------------------------ */
 
 #[derive (Debug, Clone)]
 pub enum SpecialForm {
-    /*  (QExpression) */
     Quote,
-    /*  (Cond, If Branch, Else Branch) */
     If,
-    /*  (ArgList, Body) */
     Fn,
-    /*  (Name, Value) */
     Def,
 }
 
 #[derive (Debug, Clone)]
+// TODO: Implement as linked list also, so that incremental additions to environments are possible
 pub struct Environment {
     pub special_forms: HashMap<String, SpecialForm>,
-    pub built_in_fns: HashMap<String, fn(Vec<Expression>) -> EvalResult>,
+    pub built_in_fns: HashMap<String, fn(Vec<Expression>) -> EvalResult<Expression>>,
     pub vars: HashMap<String, Expression>
 }
 


### PR DESCRIPTION
This PR materializes quite a few ideas:

1. unified environment, which is passed around by reference. Function calls should then _append_ to this env somehow; otherwise, everytime a function calls another one, the entire environment will be copied! I'm thinking of a linked-list like data structure that contains many sub-envs, each with the parent function's addition in terms of bindings. Or maybe I'm viajando pa caralho.
2. Functions are back at the same level as Atoms; it's one thing to read the `fn` reserved word: this _creates a function value_ in our language. The `Lambda(args,body)` enum value is then our internal representation of such a created value. BuiltIn functions are now at the same level as well; maybe they shouldn't since they have much in similar with user-defined functions (here called Lambdas). Both built-in functions and lambdas have a common step before their execution: evaluate their arguments and return any potential errors there, so they were given their own `enum` value at the Expression level.
3. Arrays are trivially implemented
4. `Expression::Expr` finally renamed to `Expression::List`. Who was the shithead that got the idea to call something `Expression::Expression`? Certeza que GC. Doente
5. Bunch of TODOs. Defs are trivial, so I'd say it's pretty much complete; the rest is cleanup.

ISSO FUNCIONOUUUUU
```clj
((fn [x] (x 1)) (fn [x] (+ x x)))
```