### PR TITLE
Def, local vars/environments and let bindings

### DIFF
--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -81,7 +81,7 @@ fn sum(args: Vec<Expression>) -> EvalResult<Expression> {
         })
 }
 
-pub fn initial_env() -> Environment {
+pub fn initial_env() -> (Environment, SinglyLinkedList<'static, HashMap<String, Expression>>) {
     let mut special_forms = HashMap::<String, SpecialForm>::new();
     let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult<Expression>>::new();
     let vars = HashMap::<String, Expression>::new();
@@ -95,10 +95,12 @@ pub fn initial_env() -> Environment {
     special_forms.insert("if".to_string(), SpecialForm::If);
     special_forms.insert("fn".to_string(), SpecialForm::Fn);
     special_forms.insert("def".to_string(), SpecialForm::Def);
+    special_forms.insert("let".to_string(), SpecialForm::Let);
 
-    Environment {
-        special_forms: special_forms,
-        built_in_fns: built_ins,
-        top_level_vars: vars,
-    }
+    (Environment {
+         special_forms: special_forms,
+         built_in_fns: built_ins,
+         top_level_vars: vars,
+     },
+     SinglyLinkedList::Nil)
 }

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,7 +1,8 @@
-use types::{Expression, EvaluationError, EvalResult, Atom};
+use types::{Expression, EvaluationError, EvalResult, Atom, Environment, SpecialForm, SinglyLinkedList};
+use std::collections::HashMap;
 
 // TODO: Built-in fns estão pedreiras
-pub fn neg(args: Vec<Expression>) -> EvalResult<Expression> {
+fn neg(args: Vec<Expression>) -> EvalResult<Expression> {
     let args_amount = args.len();
     if args_amount != 1 {
         Err(EvaluationError::WrongArity(1, args_amount as i64))
@@ -18,7 +19,7 @@ pub fn neg(args: Vec<Expression>) -> EvalResult<Expression> {
     }
 }
 
-pub fn mul(args: Vec<Expression>) -> EvalResult<Expression> {
+fn mul(args: Vec<Expression>) -> EvalResult<Expression> {
     let mut mtt = 1;
     for arg in args {
         if let Expression::At(atom) = arg {
@@ -36,7 +37,7 @@ pub fn mul(args: Vec<Expression>) -> EvalResult<Expression> {
     Ok(Expression::At(Atom::Int(mtt)))
 }
 
-pub fn div(args: Vec<Expression>) -> EvalResult<Expression> {
+fn div(args: Vec<Expression>) -> EvalResult<Expression> {
     let mut first_value = true;
     let mut dvv = 0;
     for arg in args {
@@ -63,7 +64,7 @@ pub fn div(args: Vec<Expression>) -> EvalResult<Expression> {
     Ok(Expression::At(Atom::Int(dvv)))
 }
 
-pub fn sum(args: Vec<Expression>) -> EvalResult<Expression> {
+fn sum(args: Vec<Expression>) -> EvalResult<Expression> {
     args.into_iter()
         .fold(Ok(Expression::At(Atom::Int(0))), |acc, arg| match acc {
             Err(err) => Err(err),
@@ -80,3 +81,24 @@ pub fn sum(args: Vec<Expression>) -> EvalResult<Expression> {
         })
 }
 
+pub fn initial_env() -> Environment {
+    let mut special_forms = HashMap::<String, SpecialForm>::new();
+    let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult<Expression>>::new();
+    let vars = HashMap::<String, Expression>::new();
+
+    built_ins.insert("+".to_string(), sum);
+    built_ins.insert("*".to_string(), mul);
+    built_ins.insert("/".to_string(), div);
+    built_ins.insert("neg".to_string(), neg);
+
+    special_forms.insert("quote".to_string(), SpecialForm::Quote);
+    special_forms.insert("if".to_string(), SpecialForm::If);
+    special_forms.insert("fn".to_string(), SpecialForm::Fn);
+    special_forms.insert("def".to_string(), SpecialForm::Def);
+
+    Environment {
+        special_forms: special_forms,
+        built_in_fns: built_ins,
+        top_level_vars: vars,
+    }
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment, FunctionType};
-use types::Expression::{List, At};
+use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment, FunctionType, SinglyLinkedList};
+use nom::lib::std::collections::{HashMap};
+use std::env::vars;
 
 fn quote_expr(to_quote: Vec<Expression>) -> EvalResult<Expression> {
     if to_quote.len() == 1 {
@@ -11,7 +11,7 @@ fn quote_expr(to_quote: Vec<Expression>) -> EvalResult<Expression> {
 
 }
 
-fn if_expr(args: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
+fn if_expr(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
     let is_truthy: fn(Expression) -> bool = |expr|
         match expr {
             Expression::At(Atom::Bool(false)) => false,
@@ -20,11 +20,11 @@ fn if_expr(args: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
         };
 
     if args.len() == 3 || args.len() == 2 {
-        let evaled_cond = eval_expression(args[0].clone(), env)?;
+        let evaled_cond = eval_expression(args[0].clone(), env, local_vars)?;
         if is_truthy(evaled_cond) {
-            eval_expression(args[1].clone(), env)
+            eval_expression(args[1].clone(), env, local_vars)
         } else if args.len() == 3 {
-            eval_expression(args[2].clone(), env)
+            eval_expression(args[2].clone(), env, local_vars)
         } else {
             Ok(Expression::At(Atom::Nil))
         }
@@ -52,12 +52,7 @@ fn lambda (args: Vec<Expression>) -> EvalResult<Expression> {
             Expression::Array(arr) => {
                 let mut arr_iterator = arr.clone().into_iter();
                 if arr_iterator.all(|x| match x { Expression::At(Atom::Symbol(_)) => true, _ => false}) {
-                    let arr_atoms = arr.into_iter().map(|x |
-                        match x {
-                            Expression::At(Atom::Symbol(s)) => Atom::Symbol(s),
-                            _ => panic!("acho que impossivel")
-                        });
-                    Ok(Expression::Function(FunctionType::Lambda(arr_atoms.collect(), Box::from(args[1].clone()))))
+                    Ok(Expression::Function(FunctionType::Lambda(arr.clone(), Box::from(args[1].clone()))))
                 } else {
                     Err(EvaluationError::WrongType("not all args were symbols".parse().unwrap()))
                 }
@@ -69,10 +64,76 @@ fn lambda (args: Vec<Expression>) -> EvalResult<Expression> {
     }
 }
 
+fn def(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+    if args.len() == 2 {
+        match args[0].clone() {
+            Expression::At(Atom::Symbol(sym)) => {
+                match lookup_symbol(&sym, env, local_vars) {
+                    Ok(Expression::SpecialForm(_)) => { Err(EvaluationError::ForbiddenDef("Cannot overwrite special form".parse().unwrap()))}
+                    Ok(Expression::Function(FunctionType::BuiltIn(_))) => { Err(EvaluationError::ForbiddenDef("Cannot overwrite built in function".parse().unwrap()))}
+                    _ => {
+                        let value = eval_expression(args[1].clone(), env, local_vars)?;
+                        env.top_level_vars.insert(sym, value.clone());
+                        Ok(value)
+                    }
+                }
+            }
+            _ => Err(EvaluationError::UnknownBinding("Cannot def a non-symbol".parse().unwrap()))
+        }
+    } else {
+        Err(EvaluationError::WrongArity(2, args.len() as i64))
+    }
+}
+
+fn tuple_even_vector(to_tuple: &Vec<Expression>) -> EvalResult<Vec<(Expression, Expression)>> {
+    let mut ret = Vec::new();
+    let mut intermediate_tuple: Option<Expression> = Option::None;
+    for half_binding in to_tuple {
+        match intermediate_tuple {
+            Option::Some(let1) => { ret.push((let1.clone(), half_binding.clone())); intermediate_tuple = Option::None }
+            Option::None => { intermediate_tuple = Option::Some(half_binding.clone()) }
+        }
+    }
+    match intermediate_tuple {
+        Option::Some(let1) => Err(EvaluationError::MustHaveEvenNumberOfForms("let binding".parse().unwrap())),
+        Option::None => { Ok(ret) }
+    }
+}
+
+fn vector_of_tuples_to_hash_map(tuples: &Vec<(Expression, Expression)>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<HashMap<String, Expression>> {
+    let mut map_of_bound_names = HashMap::new();
+    for (name, value) in tuples {
+        match name {
+            Expression::At(Atom::Symbol(sym)) => {
+                let value_to_bind = eval_expression(value.clone(), env, local_vars)?;
+                map_of_bound_names.insert(sym.clone(), value_to_bind);
+            }
+            _ => { return Err(EvaluationError::UnknownBinding("Illegal binding; only symbols".parse().unwrap())) }
+        }
+    }
+    Ok(map_of_bound_names)
+}
+
+fn let_expr(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+    if args.len() == 2 {
+        match args[0].clone() {
+            Expression::Array(vec) => {
+                let vector_of_tuples = tuple_even_vector(&vec)?;
+                let mut map_of_bound_names = vector_of_tuples_to_hash_map(&vector_of_tuples, env, local_vars)?;
+                let local_env_overwrites = SinglyLinkedList::Cons(map_of_bound_names, local_vars);
+                eval_expression(args[1].clone(), env, &local_env_overwrites)
+            }
+            _ => { Err(EvaluationError::WrongType("Second argument of let binding must be array".parse().unwrap())) }
+        }
+    } else {
+        Err(EvaluationError::WrongArity(2, args.len() as i64))
+    }
+}
+
 // TODO 2: Horrível. Fuck for loops
 fn substitute(params_fn_takes: Vec<Atom>, args_fn_is_receiving: Vec<Expression>, env: &Environment) -> EvalResult<Environment> {
     let mut new_environment = env.clone(); // TODO: Don't clone whole environment for each function call
-    let two_together = params_fn_takes.into_iter().zip(args_fn_is_receiving);
+    // let two_together = params_fn_takes.into_iter().zip(args_fn_is_receiving);
     // TODO: disgusting side-effectful map, should be a mapM_
     // let res = two_together.map(|(param,arg)| {
     //     match param {
@@ -80,25 +141,27 @@ fn substitute(params_fn_takes: Vec<Atom>, args_fn_is_receiving: Vec<Expression>,
     //         _ => Err(EvaluationError::UnknownBinding("can only bind to symbols".parse().unwrap()))
     //     }
     // });
-    for (param, arg) in two_together {
-        match param {
-            Atom::Symbol(sym) => new_environment.vars.insert(sym, arg),
-            _ => return Err(EvaluationError::UnknownBinding("can only bind to symbols".parse().unwrap()))
-        };
-    }
+    // for (param, arg) in two_together {
+    //     match param {
+    //         Atom::Symbol(sym) => new_environment.vars.insert(sym, arg),
+    //         _ => return Err(EvaluationError::UnknownBinding("can only bind to symbols".parse().unwrap()))
+    //     };
+    // }
     Ok(new_environment)
 }
 
 // TODO 3: Usar um map_m sério
-fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
-    let evaled_args = map_m(args_fn_is_receiving.into_iter().map(|x| eval_expression(x, env)).collect());
+fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+    let evaled_args = map_m(args_fn_is_receiving.into_iter().map(|x| eval_expression(x, env, local_vars)).collect());
 
     match evaled_args {
         Ok(correctly_evaled_args) => {
             match called_fn {
                 FunctionType::Lambda(params_fn_takes, body) => {
-                    let local_env = substitute(params_fn_takes, correctly_evaled_args, env)?;
-                    eval_expression(*body, &local_env)
+                    let two_together = params_fn_takes.into_iter().zip(correctly_evaled_args).collect();
+                    let mut map_of_bound_names = vector_of_tuples_to_hash_map(&two_together, env, local_vars)?;
+                    let local_env_overwrites = SinglyLinkedList::Cons(map_of_bound_names, local_vars);
+                    eval_expression(*body, env, &local_env_overwrites)
                 },
                 FunctionType::BuiltIn(built_in) => built_in(correctly_evaled_args),
             }
@@ -108,49 +171,62 @@ fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>,
 }
 
 
-fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &Environment) -> EvalResult<Expression> {
+fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
     match special_form {
         SpecialForm::Quote => quote_expr(args),
-        SpecialForm::If => if_expr(args, env),
+        SpecialForm::If => if_expr(args, env, local_vars),
         SpecialForm::Fn => lambda(args),
-        _ => { panic! ("Como vc achou um special form sem que ele exista? Lixo")}
-        /* TODO: Implement other special forms
-        SpecialForm::Def(name, value) => { Ok(*my_boxed_expr) }
-        */
+        SpecialForm::Def => def(args, env, local_vars),
+        SpecialForm::Let => let_expr(args, env, local_vars)
     }
 }
 
-fn lookup_symbol(sym: String, env: &Environment) -> EvalResult<Expression> {
-    if let Some(special_form_type) = env.special_forms.get(&sym) {
+fn lookup_vars<'a>(sym: &String, vars_layers: &'a SinglyLinkedList<HashMap<String, Expression>>) -> Option<&'a Expression> {
+    match vars_layers {
+        SinglyLinkedList::Cons(vars, tail) => {
+            if let Option::Some(val) = vars.get(sym) {
+                Option::Some(val)
+            } else {
+                lookup_vars(sym, tail)
+            }
+        }
+        SinglyLinkedList::Nil => { Option::None }
+    }
+}
+
+fn lookup_symbol(sym: &String, env: &Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>> ) -> EvalResult<Expression> {
+    if let Some(special_form_type) = env.special_forms.get(sym) {
         Ok(Expression::SpecialForm(special_form_type.clone()))
-    } else if let Some(built_in) = env.built_in_fns.get(&sym) {
+    } else if let Some(built_in) = env.built_in_fns.get(sym) {
         Ok(Expression::Function(FunctionType::BuiltIn(*built_in)))
-    } else if let Some(expr) = env.vars.get(&sym) {
+    } else if let Some(expr) = lookup_vars(sym, local_vars) {
+        Ok(expr.clone())
+    } else if let Some(expr) = env.top_level_vars.get(sym) {
         Ok(expr.clone())
     } else {
-        Err(EvaluationError::SymbolNotFound(sym))
+        Err(EvaluationError::SymbolNotFound(sym.parse().unwrap()))
     }
 }
 
-fn eval_expression(expr: Expression, env: &Environment) -> EvalResult<Expression> {
+fn eval_expression(expr: Expression, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
     match expr {
-        Expression::At(Atom::Symbol(sym)) => lookup_symbol(sym, env),
+        Expression::At(Atom::Symbol(sym)) => lookup_symbol(&sym, env, local_vars),
         Expression::At(_) => Ok(expr),
         Expression::Function(_) => Ok(expr),
         Expression::SpecialForm(_) => Err(EvaluationError::SpecialFormOutOfContext), // TODO: Impossible due to lookup
         Expression::Array(_) => Ok(expr), // TODO: Has to eval elements
         Expression::List(op, args) => {
-            let caller = eval_expression(*op, env)?;
+            let caller = eval_expression(*op, env, local_vars)?;
             match caller {
-                Expression::SpecialForm(special_form_type) => call_special_form(special_form_type.clone(), args, &env),
-                Expression::Function(fn_type) => call_function(fn_type, args, &env),
+                Expression::SpecialForm(special_form_type) => call_special_form(special_form_type.clone(), args, env, local_vars),
+                Expression::Function(fn_type) => call_function(fn_type, args, env, local_vars),
                 _ => Err(EvaluationError::NotSpecialFormOrFunction)
             }
         }
     }
 }
 
-pub fn eval(expr: Expression, env: &Environment) -> String {
-    let evaled_expr = eval_expression(expr, env);
+pub fn eval(expr: Expression, env: &mut Environment) -> String {
+    let evaled_expr = eval_expression(expr, env, &SinglyLinkedList::Nil);
     format!("{:?}", evaled_expr)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
 
     /* Construct built-in function table
            TODO: Move construction to built_in module itself */
-    let mut env = built_in::initial_env();
+    let (mut env, local_env) = built_in::initial_env();
 
     loop {
         print!("lispy_rusty>");
@@ -41,7 +41,7 @@ fn main() {
         /* TODO:  Do a more user-friendly print. Either implement the Debug trait by hand or handle it otherwise */
         match parsed_input_expression {
             Ok((_, expr)) => {
-                println!("eval: {}", eval::eval(expr, &mut env));
+                println!("eval: {}", eval::eval(expr, &mut env, &local_env));
             }
             Err(parser_error) => {
                 println!("Fuck you, boah: {:?}", parser_error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@ mod built_in;
 extern crate nom;
 
 use std::io::{self, Write};
-use std::collections::HashMap;
-use types::{SpecialForm, Expression, Atom, EvalResult, Environment};
 
 mod parser;
 mod eval;
@@ -16,6 +14,11 @@ fn main() {
     println!("Press Ctrl+c to Exit\n");
 
     let mut input_history = Vec::new();
+
+    /* Construct built-in function table
+           TODO: Move construction to built_in module itself */
+    let mut env = built_in::initial_env();
+
     loop {
         print!("lispy_rusty>");
         io::stdout().flush().unwrap(); // Flush to write prompt before getting input
@@ -34,31 +37,11 @@ fn main() {
         let to_parse = x.to_owned();
         let parsed_input_expression = parser::parse(&to_parse);
 
-        /* Construct built-in function table 
-           TODO: Move construction to built_in module itself */
-        let mut special_forms = HashMap::<String, SpecialForm>::new();
-        let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult<Expression>>::new();
-        let mut vars = HashMap::<String, Expression>::new();
-        built_ins.insert("+".to_string(), built_in::sum);
-        built_ins.insert("*".to_string(), built_in::mul);
-        built_ins.insert("/".to_string(), built_in::div);
-        built_ins.insert("neg".to_string(), built_in::neg);
-        special_forms.insert("quote".to_string(), SpecialForm::Quote);
-        special_forms.insert("if".to_string(), SpecialForm::If);
-        special_forms.insert("fn".to_string(), SpecialForm::Fn);
-        vars.insert("variavel-qualquer".to_string(), Expression::At(Atom::Int(11)));
-
-        let env = Environment {
-            special_forms: special_forms,
-            built_in_fns: built_ins,
-            vars: vars
-        };
-
         /* Print user input line (just the parsed tree for now) */
         /* TODO:  Do a more user-friendly print. Either implement the Debug trait by hand or handle it otherwise */
         match parsed_input_expression {
             Ok((_, expr)) => {
-                println!("eval: {}", eval::eval(expr, &env));
+                println!("eval: {}", eval::eval(expr, &mut env));
             }
             Err(parser_error) => {
                 println!("Fuck you, boah: {:?}", parser_error)

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use nom::lib::std::collections::LinkedList;
 
 /* TODO: Discover how to parametrize the our types.
    For example: an Expression::Function(vec, _) doesn't contain, in vec, just any atom.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use nom::lib::std::collections::LinkedList;
 
 /* TODO: Discover how to parametrize the our types.
    For example: an Expression::Function(vec, _) doesn't contain, in vec, just any atom.
@@ -23,7 +24,7 @@ pub enum Atom {
 
 #[derive(Debug, Clone)]
 pub enum FunctionType {
-    Lambda(Vec<Atom>, Box<Expression>),
+    Lambda(Vec<Expression>, Box<Expression>),
     BuiltIn(fn(Vec<Expression>) -> EvalResult<Expression>)
 }
 
@@ -45,7 +46,9 @@ pub enum EvaluationError {
     WrongType(String),
     WrongArity(i64, i64), // (Expected, Received)
     SpecialFormOutOfContext,
-    UnknownBinding(String)
+    UnknownBinding(String),
+    ForbiddenDef(String),
+    MustHaveEvenNumberOfForms(String)
 }
 
 pub type EvalResult<O> = Result<O, EvaluationError>;
@@ -57,6 +60,13 @@ pub enum SpecialForm {
     If,
     Fn,
     Def,
+    Let,
+}
+
+#[derive (Debug, Eq, PartialEq)]
+pub enum SinglyLinkedList<'a, T> {
+    Cons(T, &'a SinglyLinkedList<'a, T>),
+    Nil
 }
 
 #[derive (Debug, Clone)]
@@ -64,6 +74,6 @@ pub enum SpecialForm {
 pub struct Environment {
     pub special_forms: HashMap<String, SpecialForm>,
     pub built_in_fns: HashMap<String, fn(Vec<Expression>) -> EvalResult<Expression>>,
-    pub vars: HashMap<String, Expression>
+    pub top_level_vars: HashMap<String, Expression>
 }
 


### PR DESCRIPTION
Lots of stuff again. "built_in" module now exports an fn to create a new environment from scratch, which main uses (main is where the "REPL" of this little thing is running). Environment also is now split into two values: the original struct, and a linked list of HashMaps which contain local bindings. The there is that this implements shadowing.

For functions: whenever a function is called, its arguments are bound to the parameter names, overwriting any global defs or local vars defined in a scope "above". This is expressed by adding a head to the list, and if any inner scope expressions looks up that symbol, it's guaranteed to find the function's bindings before the upper level's ones. The way we were doing it before is just copying the entire environment any time a function was called, which is pretty redundant.

For let bindings: pretty much the same, except the names in a let binding are substituted in the same scope as the values the should hold, unlike functions, whose evaluation happens at the caller, before "going in" to the function's environment. But the basic idea is the same: add a new node to the linked list and pass that down to the body of the binding.

This is very fun c: