### PR TITLE
Additional built-ins, maps, load defs from a file

### DIFF
--- a/hello.lsrs
+++ b/hello.lsrs
@@ -1,0 +1,13 @@
+(def my-fn! (fn
+  [x y z]
+  (let [sum1 (+ x y)
+        x    (* y (if (< x y) z (neg z)))]
+   {"result" x})))
+
+(def my-other-fn! (fn
+  [j]
+  (assoc (my-fn! j j j) "sou eu" "gc")))
+
+(my-other-fn! 10)
+
+(def main! (fn [] (my-other-fn! 15)))

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -1,4 +1,4 @@
-use types::{Expression, EvaluationError, EvalResult, Atom, Environment, SpecialForm, SinglyLinkedList};
+use types::{Expression, EvaluationError, EvalResult, Atom, Environment, SpecialForm, SinglyLinkedList, MapType};
 use std::collections::HashMap;
 
 // TODO: Built-in fns estão pedreiras
@@ -104,6 +104,53 @@ fn sum(args: Vec<Expression>) -> EvalResult<Expression> {
         })
 }
 
+fn assoc(args: Vec<Expression>) -> EvalResult<Expression> {
+    if args.len() < 3 {
+        Err(EvaluationError::WrongArity(3, args.len() as i64))
+    } else if let Expression::Map(MapType::PostEvaluation(mut map)) = args[0].clone() {
+        if let Expression::At(atom) = args[1].clone() {
+            map.insert(atom, args[2].clone());
+            Ok(Expression::Map(MapType::PostEvaluation(map)))
+        } else {
+            Err(EvaluationError::WrongType("key must be atom".parse().unwrap()))
+        }
+    } else {
+        Err(EvaluationError::WrongType("can only associate in a map".parse().unwrap()))
+    }
+}
+
+fn dissoc(args: Vec<Expression>) -> EvalResult<Expression> {
+    if args.len() < 2 {
+        Err(EvaluationError::WrongArity(2, args.len() as i64))
+    } else if let Expression::Map(MapType::PostEvaluation(mut map)) = args[0].clone() {
+        if let Expression::At(atom) = &args[1] {
+            map.remove(atom);
+            Ok(Expression::Map(MapType::PostEvaluation(map)))
+        } else {
+            Err(EvaluationError::WrongType("key must be atom".parse().unwrap()))
+        }
+    } else {
+        Err(EvaluationError::WrongType("can only dissociate in a map".parse().unwrap()))
+    }
+}
+
+fn get(args: Vec<Expression>) -> EvalResult<Expression> {
+    if args.len() < 2 {
+        Err(EvaluationError::WrongArity(2, args.len() as i64))
+    } else if let Expression::Map(MapType::PostEvaluation(map)) = args[0].clone() {
+        if let Expression::At(atom) = &args[1] {
+            match map.get(atom) {
+                Some(exp) => { Ok(exp.clone()) },
+                None => { Ok(Expression::At(Atom::Nil)) },
+            }
+        } else {
+            Err(EvaluationError::WrongType("key must be atom".parse().unwrap()))
+        }
+    } else {
+        Err(EvaluationError::WrongType("can only dissociate in a map".parse().unwrap()))
+    }
+}
+
 pub fn initial_env() -> (Environment, SinglyLinkedList<'static, HashMap<String, Expression>>) {
     let mut special_forms = HashMap::<String, SpecialForm>::new();
     let mut built_ins = HashMap::<String, fn(Vec<Expression>) -> EvalResult<Expression>>::new();
@@ -115,6 +162,9 @@ pub fn initial_env() -> (Environment, SinglyLinkedList<'static, HashMap<String, 
     built_ins.insert("neg".to_string(), neg);
     built_ins.insert("eq".to_string(), eq);
     built_ins.insert("<".to_string(), compare);
+    built_ins.insert("assoc".to_string(), assoc);
+    built_ins.insert("dissoc".to_string(), dissoc);
+    built_ins.insert("get".to_string(), get);
 
     special_forms.insert("quote".to_string(), SpecialForm::Quote);
     special_forms.insert("if".to_string(), SpecialForm::If);

--- a/src/built_in.rs
+++ b/src/built_in.rs
@@ -19,6 +19,29 @@ fn neg(args: Vec<Expression>) -> EvalResult<Expression> {
     }
 }
 
+fn eq(args: Vec<Expression>) -> EvalResult<Expression> {
+    let args_amount = args.len();
+    if args_amount != 2 {
+        Err(EvaluationError::WrongArity(2, args_amount as i64))
+    } else {
+        Ok(Expression::At(Atom::Bool(args[0] == args[1])))
+    }
+}
+
+fn compare(args: Vec<Expression>) -> EvalResult<Expression> {
+    let args_amount = args.len();
+    if args_amount != 2 {
+        Err(EvaluationError::WrongArity(2, args_amount as i64))
+    } else {
+        match (&args[0], &args[1]) {
+            (Expression::At(Atom::Int(x)), Expression::At(Atom::Int(y))) => {
+                Ok(Expression::At(Atom::Bool(x < y)))
+            },
+            _ => Err(EvaluationError::WrongType("Can only compare two integers".parse().unwrap()))
+        }
+    }
+}
+
 fn mul(args: Vec<Expression>) -> EvalResult<Expression> {
     let mut mtt = 1;
     for arg in args {
@@ -90,6 +113,8 @@ pub fn initial_env() -> (Environment, SinglyLinkedList<'static, HashMap<String, 
     built_ins.insert("*".to_string(), mul);
     built_ins.insert("/".to_string(), div);
     built_ins.insert("neg".to_string(), neg);
+    built_ins.insert("eq".to_string(), eq);
+    built_ins.insert("<".to_string(), compare);
 
     special_forms.insert("quote".to_string(), SpecialForm::Quote);
     special_forms.insert("if".to_string(), SpecialForm::If);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,17 +1,18 @@
-use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment, FunctionType, SinglyLinkedList};
-use nom::lib::std::collections::{HashMap};
+use types::{Expression, EvaluationError, EvalResult, SpecialForm, Atom, Environment, FunctionType, SinglyLinkedList, MapType};
+use nom::lib::std::collections::{HashMap, VecDeque};
 use util;
 
-fn quote_expr(to_quote: Vec<Expression>) -> EvalResult<Expression> {
+pub type LocalVars<'a> = SinglyLinkedList<'a, HashMap<String, Expression>>;
+
+fn quote_expr(to_quote: VecDeque<Expression>) -> EvalResult<Expression> {
     if to_quote.len() == 1 {
         Ok(to_quote[0].clone())
     } else {
         Err(EvaluationError::WrongArity(1, to_quote.len() as i64))
     }
-
 }
 
-fn if_expr(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+fn if_expr(args: VecDeque<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
     let is_truthy: fn(Expression) -> bool = |expr|
         match expr {
             Expression::At(Atom::Bool(false)) => false,
@@ -34,7 +35,7 @@ fn if_expr(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLink
 }
 
 // TODO: Horrível
-fn lambda (args: Vec<Expression>) -> EvalResult<Expression> {
+fn lambda (args: VecDeque<Expression>) -> EvalResult<Expression> {
     if args.len() == 2 {
         match args[0].clone() {
             Expression::Array(arr) => {
@@ -52,7 +53,7 @@ fn lambda (args: Vec<Expression>) -> EvalResult<Expression> {
     }
 }
 
-fn def(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+fn def(args: VecDeque<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
     if args.len() == 2 {
         match args[0].clone() {
             Expression::At(Atom::Symbol(sym)) => {
@@ -73,7 +74,7 @@ fn def(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedLi
     }
 }
 
-fn vector_of_tuples_to_hash_map(tuples: &Vec<(Expression, Expression)>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<HashMap<String, Expression>> {
+fn vector_of_tuples_to_hash_map_symbol(tuples: &Vec<(Expression, Expression)>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<HashMap<String, Expression>> {
     let mut map_of_bound_names = HashMap::new();
     for (name, value) in tuples {
         match name {
@@ -87,12 +88,27 @@ fn vector_of_tuples_to_hash_map(tuples: &Vec<(Expression, Expression)>, env: &mu
     Ok(map_of_bound_names)
 }
 
-fn let_expr(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+fn vector_of_tuples_to_hash_map_atom(tuples: &Vec<(Expression, Expression)>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<HashMap<Atom, Expression>> {
+    let mut map_of_bound_names = HashMap::new();
+    for (name, value) in tuples {
+        match name {
+            Expression::At(atom) => {
+                let value_to_bind = eval_expression(value.clone(), env, local_vars)?;
+                map_of_bound_names.insert(atom.clone(), value_to_bind);
+            }
+            _ => { return Err(EvaluationError::UnknownBinding("Illegal binding; only symbols".parse().unwrap())) }
+        }
+    }
+    Ok(map_of_bound_names)
+}
+
+fn let_expr(args: VecDeque<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
     if args.len() == 2 {
         match args[0].clone() {
             Expression::Array(vec) => {
                 let vector_of_tuples = util::tuple_even_vector(vec)?;
-                let map_of_bound_names = vector_of_tuples_to_hash_map(&vector_of_tuples, env, local_vars)?;
+                /* TODO: This binds the let binding as a chunk! Meaning (let [x 10 y (+ 20)]) doesnt work as x is not visible to the second binding*/
+                let map_of_bound_names = vector_of_tuples_to_hash_map_symbol(&vector_of_tuples, env, local_vars)?;
                 let local_env_overwrites = SinglyLinkedList::Cons(map_of_bound_names, local_vars);
                 eval_expression(args[1].clone(), env, &local_env_overwrites)
             }
@@ -103,7 +119,7 @@ fn let_expr(args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLin
     }
 }
 
-fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+fn call_function(called_fn: FunctionType, args_fn_is_receiving: VecDeque<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
     let evaled_args = util::map_m(args_fn_is_receiving.into_iter().map(|x| eval_expression(x, env, local_vars)).collect());
 
     match evaled_args {
@@ -112,7 +128,7 @@ fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>,
                 FunctionType::BuiltIn(built_in) => built_in(correctly_evaled_args),
                 FunctionType::Lambda(params_fn_takes, body) => {
                     let two_together = params_fn_takes.into_iter().zip(correctly_evaled_args).collect();
-                    let map_of_bound_names = vector_of_tuples_to_hash_map(&two_together, env, local_vars)?;
+                    let map_of_bound_names = vector_of_tuples_to_hash_map_symbol(&two_together, env, local_vars)?;
                     let local_env_overwrites = SinglyLinkedList::Cons(map_of_bound_names, local_vars);
                     eval_expression(*body, env, &local_env_overwrites)
                 },
@@ -123,7 +139,7 @@ fn call_function(called_fn: FunctionType, args_fn_is_receiving: Vec<Expression>,
 }
 
 
-fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
+fn call_special_form(special_form: SpecialForm, args: VecDeque<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
     match special_form {
         SpecialForm::Quote => quote_expr(args),
         SpecialForm::If => if_expr(args, env, local_vars),
@@ -133,7 +149,7 @@ fn call_special_form(special_form: SpecialForm, args: Vec<Expression>, env: &mut
     }
 }
 
-fn lookup_vars<'a>(sym: &String, vars_layers: &'a SinglyLinkedList<HashMap<String, Expression>>) -> Option<&'a Expression> {
+fn lookup_vars<'a>(sym: &String, vars_layers: &'a LocalVars) -> Option<&'a Expression> {
     match vars_layers {
         SinglyLinkedList::Cons(vars, tail) => {
             if let Option::Some(val) = vars.get(sym) {
@@ -146,7 +162,7 @@ fn lookup_vars<'a>(sym: &String, vars_layers: &'a SinglyLinkedList<HashMap<Strin
     }
 }
 
-fn lookup_symbol(sym: &String, env: &Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>> ) -> EvalResult<Expression> {
+fn lookup_symbol(sym: &String, env: &Environment, local_vars: &LocalVars ) -> EvalResult<Expression> {
     if let Some(special_form_type) = env.special_forms.get(sym) {
         Ok(Expression::SpecialForm(special_form_type.clone()))
     } else if let Some(built_in) = env.built_in_fns.get(sym) {
@@ -160,27 +176,54 @@ fn lookup_symbol(sym: &String, env: &Environment, local_vars: &SinglyLinkedList<
     }
 }
 
-fn eval_expression(expr: Expression, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> EvalResult<Expression> {
-    match expr {
-        /* TODO:  This match should be further broken up. Each collection should have its own logic. */
-        Expression::At(Atom::Symbol(sym)) => lookup_symbol(&sym, env, local_vars),
-        Expression::At(_) => Ok(expr),
-        Expression::Function(_) => Ok(expr),
-        Expression::SpecialForm(_) => Err(EvaluationError::SpecialFormOutOfContext), // TODO: Impossible due to lookup
-        Expression::Array(_) => Ok(expr), // TODO: Has to eval elements
-        Expression::Map(_) => Ok(expr),   // TODO: Has to eval elements. What does eval'ing a map return? A HashMap that is only internal?
-        Expression::List(op, args) => {
-            let caller = eval_expression(*op, env, local_vars)?;
-            match caller {
-                Expression::SpecialForm(special_form_type) => call_special_form(special_form_type.clone(), args, env, local_vars),
-                Expression::Function(fn_type) => call_function(fn_type, args, env, local_vars),
-                _ => Err(EvaluationError::NotSpecialFormOrFunction)
-            }
+fn eval_array(array: &Vec<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
+    let evaled_array = array.into_iter().map(|x| eval_expression(x.clone(), env, local_vars)).collect();
+    match util::map_m(evaled_array) {
+        Ok(correctly_evaled_array) => { Ok (Expression::Array(correctly_evaled_array))}
+        Err(err) => Err(err)
+    }
+}
+
+fn eval_map(map: &MapType, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
+    match map {
+        MapType::PostEvaluation(_) => { Ok(Expression::Map(map.clone())) }
+        MapType::PreEvaluation(tuples) => {
+            let correctly_evaled_map = vector_of_tuples_to_hash_map_atom(&tuples, env, local_vars)?;
+            Ok(Expression::Map(MapType::PostEvaluation(correctly_evaled_map)))
         }
     }
 }
 
-pub fn eval(expr: Expression, env: &mut Environment, local_vars: &SinglyLinkedList<HashMap<String, Expression>>) -> String {
+fn eval_list(list_elements: &VecDeque<Expression>, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
+    // TODO: This is a bit bad, I'd rather avoid mutability and clones and shit
+    let mut here = list_elements.clone();
+
+    if here.len() == 0 {
+        Ok(Expression::List(here))
+    } else {
+        let caller = eval_expression(here[0].clone(), env, local_vars)?;
+        here.pop_front();
+        match caller {
+            Expression::SpecialForm(special_form_type) => call_special_form(special_form_type.clone(), here, env, local_vars),
+            Expression::Function(fn_type) => call_function(fn_type, here, env, local_vars),
+            _ => Err(EvaluationError::NotSpecialFormOrFunction)
+        }
+    }
+}
+
+fn eval_expression(expr: Expression, env: &mut Environment, local_vars: &LocalVars) -> EvalResult<Expression> {
+    match expr {
+        Expression::At(Atom::Symbol(sym)) => lookup_symbol(&sym, env, local_vars),
+        Expression::At(_) => Ok(expr),
+        Expression::Function(_) => Ok(expr),
+        Expression::SpecialForm(_) => Err(EvaluationError::SpecialFormOutOfContext), // TODO: Impossible due to lookup
+        Expression::Array(array) => eval_array(&array, env, local_vars),
+        Expression::Map(map) => eval_map(&map, env, local_vars),
+        Expression::List(list) => eval_list(&list, env, local_vars)
+    }
+}
+
+pub fn eval(expr: Expression, env: &mut Environment, local_vars: &LocalVars) -> String {
     let evaled_expr = eval_expression(expr, env, local_vars);
     format!("{:?}", evaled_expr)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-mod built_in;
-
 extern crate nom;
 
 use std::io::{self, Write};
@@ -7,6 +5,8 @@ use std::io::{self, Write};
 mod parser;
 mod eval;
 mod types;
+mod util;
+mod built_in;
 
 fn main() {
     /* Initial prompt and shit */

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 extern crate nom;
 
 use std::io::{self, Write};
+use nom::AsBytes;
+use types::{Environment, Expression};
+use eval::LocalVars;
 
 mod parser;
 mod eval;
@@ -8,16 +11,12 @@ mod types;
 mod util;
 mod built_in;
 
-fn main() {
+fn repl(mut env: &mut Environment, local_env: LocalVars ) {
     /* Initial prompt and shit */
-    println!("Lispy Version 0.0.0.0.1");
+    println!("Lispy Version 0.0.0.1.1");
     println!("Press Ctrl+c to Exit\n");
 
     let mut input_history = Vec::new();
-
-    /* Construct built-in function table
-           TODO: Move construction to built_in module itself */
-    let (mut env, local_env) = built_in::initial_env();
 
     loop {
         print!("lispy_rusty>");
@@ -25,27 +24,58 @@ fn main() {
 
         let mut x = String::new();
 
-        /* Read user input line */
+        /* (R)ead user input line */
         /* TODO: voltar o cursor no REPL. Ngm merece ^[[D */
         io::stdin().read_line(&mut x).expect("Failed to read line");
 
-        /* Record input */
+        /* record input */
         input_history.push(x.clone());
 
         /*  TODO; UNDERSTAND: Why does "let parsed_input_expression = parser::parse(&x.to_owned());" not work? */
-        /*  Parse input into expression tree */
+        /*  parse input into expression tree */
         let to_parse = x.to_owned();
         let parsed_input_expression = parser::parse(&to_parse);
 
-        /* Print user input line (just the parsed tree for now) */
-        /* TODO:  Do a more user-friendly print. Either implement the Debug trait by hand or handle it otherwise */
         match parsed_input_expression {
             Ok((_, expr)) => {
-                println!("eval: {}", eval::eval(expr, &mut env, &local_env));
+                /* (E)valuate the user input*/
+                let result = eval::eval(expr, &mut env, &local_env);
+                /* (P)rint result of evaluation TODO: This print should look better. Perhaps implement Debug by hand*/
+                println!("{}", result);
             }
             Err(parser_error) => {
-                println!("Fuck you, boah: {:?}", parser_error)
+                println!("Fuck you, boah: {:?}", parser_error) // TODO: Parser errors could be turned into 'syntax errors'
             }
         }
+        /* (L)oop :point_up: */
+    }
+}
+
+fn load_main_namespace(mut env: &mut Environment, local_env: LocalVars, filepath: &str) {
+    let contents = std::fs::read(&filepath).expect("carai");
+    let parsed_content = parser::parse_namespace(contents.as_bytes());
+    match parsed_content {
+        Ok((_, expressions)) => {
+            for e in expressions {
+                eval::eval(e, &mut env, &local_env);
+            }
+            let (_, main_call) = parser::parse("(main!)").expect("it is correctamundo");
+            println!("{}", eval::eval(main_call, &mut env, &local_env));
+        },
+        Err(parser_error) => {
+            println!("Fuck you, boah: {:?}", parser_error)// TODO: Parser errors could be turned into 'syntax errors'
+        }
+    }
+}
+
+fn main() {
+    /* Construct built-in function table */
+    let (mut env, local_env) = built_in::initial_env();
+
+    let args: Vec<String> = std::env::args().collect();
+    if &args[1] == "repl" {
+        repl(&mut env, local_env)
+    } else {
+        load_main_namespace(&mut env, local_env, &args[1])
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,8 @@ use nom::{branch::alt,
           IResult, AsChar};
 use nom::character::is_alphanumeric;
 use types::{Expression, Atom};
+use nom::lib::std::collections::HashMap;
+use util;
 
 fn is_space_lisp(c: u8) -> bool {
     is_space(c) || c.as_char() == ','
@@ -17,7 +19,7 @@ fn is_valid_symbol_char(c: u8) -> bool {
 }
 
 fn parse_expression_top_level(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
-    alt((parse_atom, parse_expression, parse_array))(i)
+    alt((parse_atom, parse_list, parse_array, parse_map))(i)
 }
 
 fn parse_num(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
@@ -51,6 +53,18 @@ fn parse_symbol(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::Erro
 }
 
 /* TODO: This doesn't work! Has to take into account spaces or ')' after the literal*/
+fn parse_string(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
+    let (rest, _spaces) = take_while(is_space_lisp)(i)?;
+    let (rest, _open_quotes) = char('\"')(rest)?;
+    let (rest, content) = take_while(|c: u8| {c.as_char() != '\"'})(rest)?;
+    let (rest, _close_quotes) = char('\"')(rest)?; // because take_while doesn't consume the char that fails its condition
+
+    let wat = String::from_utf8(Vec::from(content)).expect("Me dê uma porra de uma string");
+
+    Ok((rest, Expression::At(Atom::String(wat))))
+}
+
+/* TODO: This doesn't work! Has to take into account spaces or ')' after the literal*/
 fn parse_bool(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
     let (rest, _spaces) = take_while(is_space_lisp)(i)?;
     let (rest, boolean) = alt((tag("true"), tag("false")))(rest)?;
@@ -67,7 +81,7 @@ fn parse_nil(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKi
 }
 
 fn parse_atom(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
-    alt((parse_num, parse_char, parse_bool, parse_nil, parse_symbol))(i)
+    alt((parse_num, parse_char, parse_bool, parse_nil, parse_symbol, parse_string))(i)
 }
 
 fn parse_array(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
@@ -96,7 +110,40 @@ fn parse_array(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::Error
     Ok((newest_rest, Expression::Array(array)))
 }
 
-fn parse_expression(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
+fn parse_map(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
+    let (rest, _first_spaces) = take_while(is_space_lisp)(i)?;
+    let (rest, _bracket1) = char('{')(rest)?;
+
+    let mut array = Vec::new();
+
+    let mut new_rest = rest;
+    let mut should_continue = true;
+    while should_continue {
+        let could_parse = parse_expression_top_level(new_rest);
+        match could_parse {
+            Ok((other_new_rest, expr)) => {
+                array.push(expr);
+                new_rest = other_new_rest;
+            }
+            Err(_) => {
+                should_continue = false;
+            }
+        }
+    }
+    let (new_rest, _end_spaces) = take_while(is_space_lisp)(new_rest)?;
+    let (newest_rest, _paren2) = char('}')(new_rest)?;
+
+    let tuples = util::tuple_even_vector(array);
+    match tuples {
+        Ok(tuples) => {
+            Ok((newest_rest, Expression::Map(tuples)))
+        }
+        // TODO: Remove this panic
+        Err(_) => { panic!("Larga de ser burro")}
+    }
+}
+
+fn parse_list(i: &[u8]) -> IResult<&[u8], Expression, (&[u8], nom::error::ErrorKind)> {
     let (rest, _first_spaces) = take_while(is_space_lisp)(i)?;
     let (rest, _paren1) = char('(')(rest)?;
     let (rest, op_expression) = parse_expression_top_level(rest)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,30 +12,33 @@ use std::collections::HashMap;
    Expression::At(Atom::Int(val))
 
    How do we get this guarantee on the type level? */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Atom {
     Int(i64),
     Char(char),
     Bool(bool),
     Nil,
     Symbol(String),
+    String(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum FunctionType {
     Lambda(Vec<Expression>, Box<Expression>),
     BuiltIn(fn(Vec<Expression>) -> EvalResult<Expression>)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Expression {
     At(Atom),
     List(Box<Expression>, Vec<Expression>), // TODO: implement this as a linked list (which it kind of already is but very buffed)
     Array(Vec<Expression>),
+    Map(Vec<(Expression, Expression)>),
     SpecialForm(SpecialForm),
     Function(FunctionType)
 }
 
+// TODO: Make all evaluation errors return strings
 #[derive(Debug)]
 pub enum EvaluationError {
     DivideByZero,
@@ -53,7 +56,7 @@ pub enum EvaluationError {
 pub type EvalResult<O> = Result<O, EvaluationError>;
 /* ------------------------------------------------------------------------ */
 
-#[derive (Debug, Clone)]
+#[derive (Debug, Clone, Eq, PartialEq)]
 pub enum SpecialForm {
     Quote,
     If,
@@ -69,7 +72,6 @@ pub enum SinglyLinkedList<'a, T> {
 }
 
 #[derive (Debug, Clone)]
-// TODO: Implement as linked list also, so that incremental additions to environments are possible
 pub struct Environment {
     pub special_forms: HashMap<String, SpecialForm>,
     pub built_in_fns: HashMap<String, fn(Vec<Expression>) -> EvalResult<Expression>>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{VecDeque, HashMap};
 
 /* TODO: Discover how to parametrize the our types.
    For example: an Expression::Function(vec, _) doesn't contain, in vec, just any atom.
@@ -12,7 +12,7 @@ use std::collections::HashMap;
    Expression::At(Atom::Int(val))
 
    How do we get this guarantee on the type level? */
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Atom {
     Int(i64),
     Char(char),
@@ -29,11 +29,17 @@ pub enum FunctionType {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MapType {
+    PreEvaluation(Vec<(Expression, Expression)>),
+    PostEvaluation(HashMap<Atom, Expression>)
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Expression {
     At(Atom),
-    List(Box<Expression>, Vec<Expression>), // TODO: implement this as a linked list (which it kind of already is but very buffed)
+    List(VecDeque<Expression>),
     Array(Vec<Expression>),
-    Map(Vec<(Expression, Expression)>),
+    Map(MapType),
     SpecialForm(SpecialForm),
     Function(FunctionType)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,27 @@
+use types::{EvalResult, EvaluationError};
+
+pub (crate) fn map_m<Expected,PossibleError>(maybes: Vec<Result<Expected,PossibleError>>) -> Result<Vec<Expected>, PossibleError> {
+    let mut to_return = Vec::new();
+    for maybe_err in maybes {
+        match maybe_err {
+            Err(err) => return Err(err),
+            Ok(ok) => to_return.push(ok)
+        }
+    }
+    Ok(to_return)
+}
+
+pub (crate) fn tuple_even_vector<T>(to_tuple: Vec<T>) -> EvalResult<Vec<(T, T)>> {
+    let mut ret = Vec::new();
+    let mut intermediate_tuple: Option<T> = Option::None;
+    for half_binding in to_tuple {
+        match intermediate_tuple {
+            Option::Some(let1) => { ret.push((let1, half_binding)); intermediate_tuple = Option::None }
+            Option::None => { intermediate_tuple = Option::Some(half_binding) }
+        }
+    }
+    match intermediate_tuple {
+        Option::Some(_) => Err(EvaluationError::MustHaveEvenNumberOfForms("let binding".parse().unwrap())),
+        Option::None => { Ok(ret) }
+    }
+}


### PR DESCRIPTION
Again many ideas! a bunch of things have been left pending, but now it does look a lot more like the thing we need now is just cleanup.

1. Maps have two kinds, "Pre" and "Post" evaluation. The reason is because for a map to be syntactically valid, it just has to have an even number of also syntactically valid expressions. This is represented by a vector of tuples. However, if we want to lookup something in an actual map (not just its textual representation, which is what the parser handles), or add to it, we want to be an actual hash data structure, and this is represented by a Rust HashMap.
2. Loading from a namespace/file just evals everything in the file's top-level (which will normally have a bunch of `def`s) then just tries to evaluate the `main!` function _in the same environment_. Obviously if this were a real language there would be the ability to require other namespaces and shit.
3. The rest of the built-ins added here are actually still lacking. There's no `cons`, `conj`, string manipulation or anything else that would make the language useful. However, `assoc`s and `dissoc`s and `get`s on maps are already quite fun to play around with c: